### PR TITLE
Added --ignore-namespace to emmocheck 

### DIFF
--- a/docs/tools-instructions.md
+++ b/docs/tools-instructions.md
@@ -47,8 +47,10 @@ Tool for checking that ontologies conform to EMMO conventions.
       --skip, -s ShellPattern
         		    Shell pattern matching tests to skip.  This option may be
                             provided multiple times.
-      --url-from-catalog, -u, 
+      --url-from-catalog, -u 
 			    Get url from catalog file.
+      --ignore-namespace, -n
+                            Namespace to be ignored. Can be given multiple times
 
 
 ### Examples:
@@ -56,6 +58,8 @@ Tool for checking that ontologies conform to EMMO conventions.
     emmocheck http://emmo.info/emmo/1.0.0-alpha2
     emmocheck --database demo.sqlite3 http://www.emmc.info/emmc-csa/demo#
     emmocheck -l emmo.owl (in folder to which emmo was downloaded locally) 
+    emmocheck --check-imported --ignore-namespace=physicalistic --verbose --url-from-catalog emmo.owl (in folder with downloaded EMMO)
+    
 (Missing example with local and path, and url_from_catalog)
 
 ### Example configuration file:

--- a/emmo/__init__.py
+++ b/emmo/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-__version__ = '1.0.0-alpha-18'
+__version__ = '1.0.0-alpha-19'
 
 # Ensure correct Python version
 if sys.version_info < (3, 6):

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -212,8 +212,6 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
         ))
         exceptions.update(self.get_config('test_namespace.exceptions', ()))
         def checker(onto,ignore_namespace):
-            print(onto)
-            print(ignore_namespace)
             print(list(itertools.chain(onto.classes(),
                                      onto.object_properties(),
                                      onto.data_properties(),
@@ -224,16 +222,8 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
                                      onto.data_properties(),
                                      onto.individuals(),
                                      onto.annotation_properties()):
-                print('in checker 1')
-                print(ignore_namespace)
-                print(onto.base_iri)
-                print(e)
                 if e not in visited and repr(e) not in exceptions:
                     visited.add(e)
-                    #print(e.iri)
-                    print('inchecker 2')
-                    print(ignore_namespace)
-                    print(onto.base_iri)
                     if onto.base_iri not in ignore_namespace:
 
                         with self.subTest(
@@ -254,7 +244,6 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
                         checker(imp_onto, ignore_namespace)
 
         visited = set()
-        print('before checker')
         if list(filter(self.onto.base_iri.strip('#').endswith, 
                        self.ignore_namespace)) != []:
             print('Skipping namespace: ' + self.onto.base_iri)

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -212,7 +212,8 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
         ))
         exceptions.update(self.get_config('test_namespace.exceptions', ()))
         def checker(onto, ignore_namespace):
-            if onto.base_iri.rstrip('#') in ignore_namespace:
+            if list(filter(onto.base_iri.strip('#').endswith,
+                           self.ignore_namespace)) != []:
                 print('Skipping namespace: ' + self.onto.base_iri)
                 return
             entities = itertools.chain(onto.classes(),

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -211,7 +211,6 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
             'manufacturing.EngineeredMaterial',
         ))
         exceptions.update(self.get_config('test_namespace.exceptions', ()))
-
         def checker(onto):
             for e in itertools.chain(onto.classes(),
                                      onto.object_properties(),
@@ -236,7 +235,10 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
                     checker(imp_onto)
 
         visited = set()
-        checker(self.onto)
+        if self.onto.base_iri not in self.ignore_namespace:
+            checker(self.onto)
+        else:
+            print('Skipping namespace: ' + self.onto.base_iri)
 
 
 def main():
@@ -281,6 +283,10 @@ def main():
     parser.add_argument(
         '--url-from-catalog', '-u', action='store_true',
         help=('Get url from catalog file'))
+    parser.add_argument(
+        '--ignore-namespace', '-in', action='append', default=[],
+        help=('Base_iri for namespace to be ignored. Can be given multiple '
+              'times'))
 
     try:
         args, argv = parser.parse_known_args()
@@ -310,6 +316,7 @@ def main():
     # Store settings TestEMMOConventions
     TestEMMOConventions.onto = onto
     TestEMMOConventions.check_imported = args.check_imported
+    TestEMMOConventions.ignore_namespace = args.ignore_namespace
 
     # Configure tests
     verbosity = 2 if args.verbose else 1

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -215,14 +215,11 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
             if onto.base_iri.rstrip('#') in ignore_namespace:
                 print('Skipping namespace: ' + self.onto.base_iri)
                 return
-            if self.check_imported:
-                entities = onto.get_entities()
-            else:
-                entities = itertools.chain(onto.classes(),
-                                            onto.object_properties(),
-                                            onto.data_properties(),
-                                            onto.individuals(),
-                                            onto.annotation_properties())
+            entities = itertools.chain(onto.classes(),
+                                       onto.object_properties(),
+                                       onto.data_properties(),
+                                       onto.individuals(),
+                                       onto.annotation_properties())
             for e in entities:
                 if e not in visited and repr(e) not in exceptions:
                     visited.add(e)
@@ -233,11 +230,12 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
                             msg='the final part of entity IRIs must be their '
                             'name')
                         self.assertEqual(
-                            e.iri, e.namespace.base_iri + e.name,
+                            e.iri, onto.base_iri + e.name,
                             msg='IRI %r does not correspond to module '
                             'namespace: %r' % (e.iri, onto.base_iri))
 
             if self.check_imported:
+                print(onto.imported_ontologies)
                 for imp_onto in onto.imported_ontologies:
                     checker(imp_onto, ignore_namespace)
 

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -212,11 +212,6 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
         ))
         exceptions.update(self.get_config('test_namespace.exceptions', ()))
         def checker(onto,ignore_namespace):
-            print(list(itertools.chain(onto.classes(),
-                                     onto.object_properties(),
-                                     onto.data_properties(),
-                                     onto.individuals(),
-                                     onto.annotation_properties())))
             for e in itertools.chain(onto.classes(),
                                      onto.object_properties(),
                                      onto.data_properties(),

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -236,11 +236,14 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
                             'namespace: %r' % (e.iri, onto.base_iri))
 
             if self.check_imported:
-                print(onto.imported_ontologies)
                 for imp_onto in onto.imported_ontologies:
-                    checker(imp_onto, ignore_namespace)
+                    if imp_onto not in visited_onto:
+                        #print(imp_onto)
+                        visited_onto.add(imp_onto)
+                        checker(imp_onto, ignore_namespace)
 
         visited = set()
+        visited_onto = set()
         if list(filter(self.onto.base_iri.strip('#').endswith,
                        self.ignore_namespace)) != []:
             print('Skipping namespace: ' + self.onto.base_iri)

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -295,7 +295,7 @@ def main():
         help=('Get url from catalog file'))
     parser.add_argument(
         '--ignore-namespace', '-n', action='append', default=[],
-        help=('Base_iri for namespace to be ignored. Can be given multiple '
+        help=('Namespace to be ignored. Can be given multiple '
               'times'))
 
     try:

--- a/emmo/emmocheck.py
+++ b/emmo/emmocheck.py
@@ -212,7 +212,7 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
         ))
         exceptions.update(self.get_config('test_namespace.exceptions', ()))
         def checker(onto, ignore_namespace):
-            if onto.base_iri not in ignore_namespace:
+            if onto.base_iri in ignore_namespace:
                 return
             for e in onto.get_entities():
                 if e not in visited and repr(e) not in exceptions:
@@ -230,7 +230,7 @@ class TestFunctionalEMMOConventions(TestEMMOConventions):
 
             if self.check_imported:
                 for imp_onto in onto.imported_ontologies:
-                    checker(imp_onto)
+                    checker(imp_onto, ignore_namespace)
 
         visited = set()
         if list(filter(self.onto.base_iri.strip('#').endswith,
@@ -292,7 +292,6 @@ def main():
         sys.argv[1:] = argv
     except SystemExit as e:
         os._exit(e.code)  # Exit without traceback on invalid arguments
-    print(args)
     # Append to onto_path
     for paths in args.path:
         for path in paths.split(','):
@@ -310,14 +309,7 @@ def main():
     onto.load(only_local=args.local,
               url_from_catalog=args.url_from_catalog,
               catalog_file=args.catalog_file)
-    print(onto)
-    print(onto.Atom)
-    print(type(onto.Atom))
-    print(list(itertools.chain(onto.classes(),
-                               onto.object_properties(),
-                               onto.data_properties(),
-                               onto.individuals(),
-                               onto.annotation_properties())))
+
     # Store settings TestEMMOConventions
     TestEMMOConventions.onto = onto
     TestEMMOConventions.check_imported = args.check_imported

--- a/emmo/utils.py
+++ b/emmo/utils.py
@@ -128,12 +128,12 @@ def read_catalog(path, catalog_file='catalog-v001.xml', recursive=False,
     absolute paths.
 
     The `catalog_file` argument spesifies the catalog file name and is
-    used if `path` is used when `recursive` is true and if `path` is a
+    used if `path` is used when `recursive` is true or when `path` is a
     directory.
 
-    If `recursive` is true, catalog files in sub-folders are read.
+    If `recursive` is true, catalog files in sub-folders are also read.
 
-    If `return_paths` is true, a list of directory paths with source
+    If `return_paths` is true, a set of directory paths to source
     files is returned in addition to the default dict.
     """
     iris = {}


### PR DESCRIPTION
It is now possible to ignore the a given namespace by:

emmocheck --ignore-namespace=http://emmo.info/emmo/emmo-inferred# emmo-inferred

However, this is not the same as ignoring submodules so does not work correctly yet. When  you load an ontology, the base_iri is the same for the whole ontology...