### PR TITLE
Ontodoc pdf

### DIFF
--- a/emmo/ontodoc.py
+++ b/emmo/ontodoc.py
@@ -1097,7 +1097,7 @@ def get_maxwidth(format):
 
 
 def get_docpp(ontodoc, infile, figdir='genfigs', figformat='png',
-              maxwidth=None):
+              maxwidth=None, imported=False):
     """Read `infile` and return a new docpp instance."""
     if infile:
         with open(infile, 'rt') as f:
@@ -1108,6 +1108,6 @@ def get_docpp(ontodoc, infile, figdir='genfigs', figformat='png',
         basedir = '.'
 
     docpp = DocPP(template, ontodoc, basedir=basedir, figdir=figdir,
-                  figformat=figformat, maxwidth=maxwidth)
+                  figformat=figformat, maxwidth=maxwidth, imported=imported)
 
     return docpp

--- a/examples/emmodoc/README.md
+++ b/examples/emmodoc/README.md
@@ -20,8 +20,8 @@ Similarly, for generating pdf documentation, enter this directory and run
 
 By default, we have configured pandoc to use xelatex for better unicode
 support.  It is possible to change these settings in
-[pandoc-args.yaml](pandoc-args.yaml) and
-[pandoc-pdf-args.yaml](pandoc-pdf-args.yaml).
+[pandoc-options.yaml](pandoc-options.yaml) and
+[pandoc-pdf-options.yaml](pandoc-pdf-options.yaml).
 
 
 Content of this directory
@@ -38,10 +38,10 @@ Content of this directory
 ### `pandoc` configuration files
   * [emmodoc-meta.yaml](emmodoc-meta.yaml): Metadata for EMMO, like title,
     authers, abstract, etc.
-  * [pandoc-args.yaml](pandoc-args.yaml): General pandoc options.
-  * [pandoc-html-args.yaml](pandoc-html-args.yaml): Additional pandoc options
+  * [pandoc-options.yaml](pandoc-options.yaml): General pandoc options.
+  * [pandoc-html-options.yaml](pandoc-html-options.yaml): Additional pandoc options
     for html generation.
-  * [pandoc-pdf-args.yaml](pandoc-pdf-args.yaml): Additional pandoc options
+  * [pandoc-pdf-options.yaml](pandoc-pdf-options.yaml): Additional pandoc options
     for pdf generation.
   * [pandoc-html.css](pandoc-html.css): css file used for html generation.
   * [pandoc-template.html](pandoc-template.html): Modified copy of the
@@ -69,7 +69,7 @@ by pandoc), you can write your `ontodoc` template in markdown (with
   * Copy all the files starting with `pandoc-` to a new directory.
   * Create a metadata yaml file for your ontology. You can use
     [emmodoc-meta.yaml](emmodoc-meta.yaml) as a template.
-  * Update [pandoc-args.yaml](pandoc-args.yaml).  Especially change:
+  * Update [pandoc-options.yaml](pandoc-options.yaml).  Especially change:
       - `input-files` to the name of your new yaml metadata file
       - `logo` to the path of your logo (or remove it)
       - `titlegraphic` to the path of your title figure (or remove it)

--- a/tools/ontodoc
+++ b/tools/ontodoc
@@ -19,7 +19,13 @@ import owlready2  # noqa: E402
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Tool for documenting ontologies.')
+        description='Tool for documenting ontologies.',
+        epilog='The easiest way to generate nice-looking documentation '
+        'using pandoc is to copy the emmodoc example to the current '
+        'directory and adapt it.  See '
+        'https://github.com/emmo-repo/EMMO-python/tree/master/examples/emmodoc '
+        'for more info.'
+    )
     parser.add_argument(
         'iri', metavar='IRI',
         help='File name or URI of the ontology to document.')
@@ -80,9 +86,10 @@ def main():
         '--pandoc-option', '-p', metavar='STRING', action='append',
         dest='pandoc_options',
         help='Additional pandoc long options overriding those read from '
-        '--pandoc-option-file.  It is possible to remove pandoc option --XXX '
-        'with "--pandoc-option=no-XXX".  This option may be provided multiple '
-        'times.')
+        '--pandoc-option-file.  Use "--pandoc-option=XXX=Y" to add pandoc '
+        'option --XXX=Y. It is also possible to remove pandoc option --XXX '
+        'with "--pandoc-option=no-XXX".  This option may be provided '
+        'multiple times.')
     parser.add_argument(
         '--pandoc-option-file', '-P', metavar='FILE', action='append',
         dest='pandoc_option_files',

--- a/tools/ontograph
+++ b/tools/ontograph
@@ -186,8 +186,9 @@ def main():
             relations=relations,
             edgelabels=args.edgelabels, addnodes=args.addnodes,
             addconstructs=args.addconstructs,
-            parents=args.parents,
         )
+        if args.parents:
+            graph.add_parents(args.parents)
 
         if args.legend:
             graph.add_legend()


### PR DESCRIPTION
The pdf generations seems to work, but not out of the box. The easiest is to copy and adapt the emmodoc example.

This is now documented in the ontodoc --help message. The emmodoc example README file has also been updated.

Also added option --imported to ontodoc.

Some syntactic flake8 warnings has also been addressed.