### PR TITLE
Require reflib 5.0.0 or later for correct turtle serialisation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ graphviz
 PyYAML
 blessings
 Pygments
-rdflib
+rdflib>=5.0.0
 semver
 pydot


### PR DESCRIPTION
rdflib prior to 5.0.0 serialises real literals syntactically wrong in turtle.
See https://github.com/RDFLib/rdflib/issues/1043.