### PR TITLE
Update publish workflow + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  # Should be bigger than or equal to the total number of dependencies (currently 9)
+  open-pull-requests-limit: 15
+  target-branch: master
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: master

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -2,26 +2,26 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel
         pip install -r requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Build source and build distributions
+      run: python ./setup.py sdist bdist_wheel
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This PR closes #115 by updating the publish to PyPI workflow. Note, the workflow will only run if a GitHub release is _published_. I.e., one can create draft releases and hold off publishing it until it's relevant.

It's worth noting that the built distributions (bdist) rely on the OS, here being Ubuntu 20.04. If a specific OS is desired, the `runs-on` value should be changed accordingly.

This PR also adds dependabot, which will run for two different cases:
- **pip**
  Monday mornings, it will run to check if there are newer versions released for the packages specified in `requirements.txt`, comparing to the versions specified in said file. Since only a single package has a version specified (Owlready2), it will be the only one targeted at this point in time.
- **actions**
  Every weekday morning, it will check whether there are newer versions for the actions used in the GitHub Actions workflows.

Finally, I've updated the used actions in both workflows to the latest.