### PR TITLE
Update CI 

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,6 +1,10 @@
 name: CI Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -87,3 +87,24 @@ jobs:
         #python step3_instantiate.py
         #python step4_map_instance.py
         cd -
+
+  build_package:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+        pip install -r requirements.txt
+
+    - name: Build source and built distributions
+      run: python ./setup.py sdist bdist_wheel

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -20,8 +20,7 @@ jobs:
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings
-        flake8 . --count --exit-zero --max-line-length=79 --statistics
+        flake8 . --count --statistics
 
   tests:
     name: Pytest and demos

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -91,6 +91,10 @@ jobs:
   build_package:
     runs-on: ubuntu-latest
 
+    env:
+      SDIST_DIR: sdist_action
+      BDIST_DIR: bdist_action
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -107,4 +111,26 @@ jobs:
         pip install -r requirements.txt
 
     - name: Build source and built distributions
-      run: python ./setup.py sdist bdist_wheel
+      run: python setup.py sdist bdist_wheel
+
+    - name: Check build and installation of PyPI source distribution
+      run: |
+        python setup.py -v sdist -d ${SDIST_DIR} bdist_wheel -d ${BDIST_DIR}
+        SDIST_FILE=$( ls ${SDIST_DIR}/ )
+        echo "BDIST_FILE=$( ls ${BDIST_DIR}/ )" >> $GITHUB_ENV
+        ORIGINAL_PWD=$(pwd)
+        mkdir -p /tmp/installation_dir
+        cd /tmp/installation_dir
+        pip install ${ORIGINAL_PWD}/${SDIST_DIR}/${SDIST_FILE}
+
+    - name: Remove installation again
+      run: pip uninstall -y EMMO
+
+    - name: Install built distribution (wheel)
+      run: |
+        ORIGINAL_PWD=$(pwd)
+
+        if [ "${ORIGINAL_PWD}" == "/tmp/installation_dir" ]; then echo "Wrong original dir: ${ORIGINAL_PWD}"; exit 1; fi
+        mkdir -p /tmp/installation_dir
+        cd /tmp/installation_dir
+        pip install ${ORIGINAL_PWD}/${BDIST_DIR}/${{ env.BDIST_FILE }}

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,6 +1,6 @@
 name: CI Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -4,29 +4,16 @@ on: [push, pull_request]
 
 jobs:
 
-  build:
+  lint:
+    name: Lint with flake8
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        python-version: [3.7]
-
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Check Ubuntu version we are running under
-      run: |
-        uname -a
-        sudo apt-get update
-
-    - name: Current environment
-      run: |
-        env
+        python-version: 3.7
 
     - name: Lint with flake8
       run: |
@@ -35,6 +22,64 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --max-line-length=79 --statistics
+
+  tests:
+    name: Pytest and demos
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install other dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+        sudo apt-get install -y graphviz
+
+    - name: Install EMMO-python
+      run: python setup.py install
+
+    - name: Test with pytest
+      run: pytest
+
+    - name: Run vertical demo
+      run: |
+        cd demo/vertical
+        #python define_ontology.py
+        #python plot_ontology.py
+        cd -
+    - name: Run horizontal demo
+      run: |
+        cd demo/horizontal
+        #python step1_generate_metadata.py
+        #python step2_define_metadata.py
+        #python step3_instantiate.py
+        #python step4_map_instance.py
+        cd -
+
+  documentation:
+    name: EMMO documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Check Ubuntu version we are running under
+      run: |
+        uname -a
+        sudo apt-get update
+
+    - name: Current environment
+      run: env
 
     - name: Install pandoc 2.1.2
       run: |
@@ -60,11 +105,6 @@ jobs:
       run: |
         python setup.py install
 
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest
-
     - name: Create EMMO documentation
       run: |
         cd examples/emmodoc
@@ -73,24 +113,9 @@ jobs:
         python ../../tools/ontodoc -t emmo.md emmo-inferred emmo.pdf
         cd -
 
-    - name: Run vertical demo
-      run: |
-        cd demo/vertical
-        #python define_ontology.py
-        #python plot_ontology.py
-        cd -
-    - name: Run horizontal demo
-      run: |
-        cd demo/horizontal
-        #python step1_generate_metadata.py
-        #python step2_define_metadata.py
-        #python step3_instantiate.py
-        #python step4_map_instance.py
-        cd -
-
   build_package:
+    name: Build Python package and install (integrity test)
     runs-on: ubuntu-latest
-
     env:
       SDIST_DIR: sdist_action
       BDIST_DIR: bdist_action

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,7 +18,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel
         pip install -r requirements.txt
-    - name: Build source and build distributions
+    - name: Build source and built distributions
       run: python ./setup.py sdist bdist_wheel
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -19,7 +19,7 @@ jobs:
         pip install setuptools wheel
         pip install -r requirements.txt
     - name: Build source and built distributions
-      run: python ./setup.py sdist bdist_wheel
+      run: python setup.py sdist bdist_wheel
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md LICENSE.txt
+include README.md LICENSE.txt requirements.txt
 recursive-exclude .github *
 exclude .readthedocs.yml
 

--- a/emmo/graph.py
+++ b/emmo/graph.py
@@ -670,6 +670,7 @@ def get_module_dependencies(iri_or_onto, strip_base=None):
             return base_iri
 
     visited = set()
+
     def setmodules(onto):
         for o in onto.imported_ontologies:
             if onto.base_iri in modules:
@@ -750,6 +751,7 @@ def check_module_dependencies(modules, verbose=True):
     get_module_dependencies().
     """
     visited = set()
+
     def get_deps(iri, excl=None):
         """Returns a set with all dependencies of `iri`, excluding `excl` and
         its dependencies."""

--- a/emmo/ontology.py
+++ b/emmo/ontology.py
@@ -488,7 +488,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
         for onto in self.imported_ontologies:
             if onto not in visited:
                 visited.add(onto)
-                onto.__class__ = self.__class__  # magically change type of onto
+                onto.__class__ = self.__class__  # change type of onto (magic)
                 try:
                     return onto._get_by_label(label, visited=visited)
                 except NoSuchLabelError:
@@ -542,8 +542,10 @@ class Ontology(owlready2.Ontology, OntoGraph):
         update(self.get_entities(
             classes=False, individuals=False, annotation_properties=False))
 
-    def rename_entities(self,
-                   annotations=('prefLabel', 'label', 'altLabel')):
+    def rename_entities(
+        self,
+        annotations=('prefLabel', 'label', 'altLabel'),
+    ):
         """Set `name` of all entities to the first non-empty annotation in
         `annotations`.
 

--- a/emmo/patch.py
+++ b/emmo/patch.py
@@ -117,9 +117,6 @@ def get_indirect_is_a(self, skip_classes=True):
     return s
 
 
-
-
-
 #
 # Extending PropertyClass (properties)
 #
@@ -171,6 +168,7 @@ def get_typename(self):
 # Extending Namespace
 #
 orig_namespace_init = Namespace.__init__
+
 
 def namespace_init(self, world_or_ontology, base_iri, name=None):
     orig_namespace_init(self, world_or_ontology, base_iri, name)

--- a/emmo/tests/test_modules.py
+++ b/emmo/tests/test_modules.py
@@ -7,8 +7,11 @@ thisdir = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(1, os.path.abspath(os.path.join(thisdir, '..', '..')))
 from emmo import get_ontology  # noqa: E402, F401
 
-from emmo.graph import (plot_modules, get_module_dependencies,
-                        check_module_dependencies)  # noqa: E402, F401
+from emmo.graph import (  # noqa: E402, F401
+    plot_modules,
+    get_module_dependencies,
+    check_module_dependencies,
+)
 
 
 iri = 'http://emmo.info/emmo/1.0.0-alpha2'

--- a/emmo/utils.py
+++ b/emmo/utils.py
@@ -221,7 +221,9 @@ def convert_imported(input, output, input_format=None, output_format='xml',
                 s = f.read()
             for path in d.values():
                 newpath = os.path.splitext(path)[0] + outext
-                s = s.replace(os.path.basename(path), os.path.basename(newpath))
+                s = s.replace(
+                    os.path.basename(path), os.path.basename(newpath)
+                )
             with open(os.path.join(outdir, catalog_file), mode='wt') as f:
                 f.write(s)
     else:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def fglob(patt):
 baseurl = 'https://raw.githubusercontent.com/emmo-repo/EMMO-python/master/'
 with open(os.path.join(rootdir, 'README.md'), 'rt') as f:
     long_description = re.sub(
-        r'(\[[^]]+\])\(([^:)]+)\)', rf'\1(%s\2)' % baseurl, f.read())
+        r'(\[[^]]+\])\(([^:)]+)\)', r'\1(%s\2)' % baseurl, f.read())
 
 # Read requirements from requirements.txt file
 with open(os.path.join(rootdir, 'requirements.txt'), 'rt') as f:


### PR DESCRIPTION
Summary of what has changed in this PR concerning CI:
- Use PyPI token for publishing (closes #118).
- Add a CI test to build and install the Python package to ensure any new changes doesn't disrupt building the package.
  This is done for both the source distribution (`sdist`) and for the built distribution (`bdist_wheel`) using `ubuntu-latest`.
- Run CI for all PRs and _only_ for pushes to `master`.
- Split up CI job `build` to individual jobs to have a better overview.
- Provide the `flake8` linting with some teeth, in the form of _not_ turning all errors into warnings.

Code fixes:
- Based on the `flake8` linting, the files have been updated accordingly.
- Add `requirements.txt` to the `MANIFEST.in` as the "build and install Python package"-test failed due to missing the `requirements.txt` file.
  You might never have experienced this, if you didn't install from PyPI.