### PR TITLE
Save to turtle and ontology annotations (via the metadata attribute)

### DIFF
--- a/emmo/ontology.py
+++ b/emmo/ontology.py
@@ -23,7 +23,7 @@ import owlready2
 from owlready2 import locstr
 
 from .utils import asstring, read_catalog, infer_version, convert_imported
-from .utils import FMAP, isinteractive, ReadCatalogError
+from .utils import FMAP, OWLREADY2_FORMATS, isinteractive, ReadCatalogError
 from .factpluspluswrapper.sync_factpp import sync_reasoner_factpp
 from .ontograph import OntoGraph  # FIXME: deprecate...
 
@@ -154,7 +154,10 @@ class Ontology(owlready2.Ontology, OntoGraph):
         return sorted(s)
 
     def __getitem__(self, name):
-        return self.__getattr__(name)
+        item = super().__getitem__(name)
+        if not item:
+            item = self.get_by_label(name)
+        return item
 
     def __getattr__(self, name):
         attr = super().__getattr__(name)
@@ -163,7 +166,14 @@ class Ontology(owlready2.Ontology, OntoGraph):
         return attr
 
     def __contains__(self, other):
-        return bool(self.world[other])
+        if self.world[other]:
+            return True
+        try:
+            self.get_by_label(other)
+        except NoSuchLabelError:
+            return False
+        else:
+            return True
 
     def __objclass__(self):
         # Play nice with inspect...
@@ -197,6 +207,10 @@ class Ontology(owlready2.Ontology, OntoGraph):
 
         if self._special_labels and value in self._special_labels:
             return self._special_labels[value]
+
+        e = self.world[self.base_iri + value]
+        if e:
+            return e
 
         raise NoSuchLabelError('No label annotations matches %s' % value)
 
@@ -377,7 +391,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
         try:
             self.loaded = False
             fmt = format if format else guess_format(resolved_url, fmap=FMAP)
-            if fmt and fmt not in ('xml', 'ntriples'):
+            if fmt and fmt not in OWLREADY2_FORMATS:
                 # Convert filename to rdfxml before passing it to owlready2
                 g = rdflib.Graph()
                 g.parse(resolved_url, format=fmt)
@@ -434,7 +448,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
                                         format='rdfxml',
                                         **kwargs)
 
-    def save(self, filename=None, format='rdfxml', overwrite=False, **kwargs):
+    def save(self, filename=None, format=None, overwrite=False, **kwargs):
         """Writes the ontology to file.
 
         If `overwrite` is true and filename exists, it will be removed
@@ -442,7 +456,18 @@ class Ontology(owlready2.Ontology, OntoGraph):
         """
         if overwrite and filename and os.path.exists(filename):
             os.remove(filename)
-        super().save(file=filename, format=format, **kwargs)
+
+        if not format:
+            format = guess_format(filename, fmap=FMAP)
+
+        if format in OWLREADY2_FORMATS:
+            super().save(file=filename, format=format, **kwargs)
+        else:
+            with tempfile.NamedTemporaryFile(suffix='.owl') as f:
+                super().save(file=f.name, format='rdfxml', **kwargs)
+                g = rdflib.Graph()
+                g.parse(f.name, format='xml')
+                g.serialize(destination=filename, format=format)
 
     def get_imported_ontologies(self, recursive=False):
         """Return a list with imported ontologies.
@@ -712,8 +737,9 @@ class Ontology(owlready2.Ontology, OntoGraph):
     def get_annotations(self, entity):
         """Returns a dict with annotations for `entity`.  Entity may be given
         either as a ThingClass object or as a label."""
-        warnings.warn('Ontology.get_annotations(cls) is deprecated.  '
-                      'Use cls.get_annotations() instead.', DeprecationWarning)
+        warnings.warn('Ontology.get_annotations(entity) is deprecated.  '
+                      'Use entity.get_annotations() instead.',
+                      DeprecationWarning)
 
         if isinstance(entity, str):
             entity = self.get_by_label(entity)
@@ -849,7 +875,8 @@ class Ontology(owlready2.Ontology, OntoGraph):
             if not version:
                 raise TypeError(
                     'Either `version` or `version_iri` must be provided')
-            version_iri = self.base_iri.rstrip('#/') + '/' + version
+            head, tail = self.base_iri.rstrip('#/').rsplit('/', 1)
+            version_iri = '/'.join([head, version, tail])
 
         self._add_obj_triple_spo(
             s=self.storid,

--- a/emmo/patch.py
+++ b/emmo/patch.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """This module injects some additional methods into owlready2 classes."""
+import types
 
 import owlready2
 from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
+from owlready2 import Metadata
+from owlready2 import rdf_type, owl_annotation_property
 
 
 # Improve default rendering of entities
@@ -117,6 +120,15 @@ def get_indirect_is_a(self, skip_classes=True):
     return s
 
 
+# Inject methods into ThingClass
+setattr(ThingClass, '__dir__', _dir)
+setattr(ThingClass, 'get_preferred_label', get_preferred_label)
+setattr(ThingClass, 'get_parents', get_parents)
+setattr(ThingClass, 'get_annotations', get_class_annotations)
+setattr(ThingClass, 'disjoint_with', disjoint_with)
+setattr(ThingClass, 'get_indirect_is_a', get_indirect_is_a)
+
+
 #
 # Extending PropertyClass (properties)
 #
@@ -135,6 +147,11 @@ def get_property_annotations(self, all=False, imported=True):
         return d
     else:
         return {k: v for k, v in d.items() if v}
+
+
+setattr(PropertyClass, 'get_preferred_label', get_preferred_label)
+setattr(PropertyClass, 'get_parents', get_parents)
+setattr(PropertyClass, 'get_annotations', get_property_annotations)
 
 
 #
@@ -157,11 +174,19 @@ def get_individual_annotations(self, all=False, imported=True):
         return {k: v for k, v in d.items() if v}
 
 
+# Method names for individuals must be different from method names for classes
+type.__setattr__(Thing, 'get_preflabel', get_preferred_label)
+type.__setattr__(Thing, 'get_individual_annotations',
+                 get_individual_annotations)
+
+
 #
 # Extending Restriction
 #
 def get_typename(self):
     return owlready2.class_construct._restriction_type_2_label[self.type]
+
+setattr(Restriction, 'get_typename', get_typename)
 
 
 #
@@ -175,24 +200,73 @@ def namespace_init(self, world_or_ontology, base_iri, name=None):
     if self.name.endswith('.ttl'):
         self.name = self.name[:-4]
 
-
-# Inject methods into Owlready2 classes
-setattr(ThingClass, '__dir__', _dir)
-setattr(ThingClass, 'get_preferred_label', get_preferred_label)
-setattr(ThingClass, 'get_parents', get_parents)
-setattr(ThingClass, 'get_annotations', get_class_annotations)
-setattr(ThingClass, 'disjoint_with', disjoint_with)
-setattr(ThingClass, 'get_indirect_is_a', get_indirect_is_a)
-
-setattr(PropertyClass, 'get_preferred_label', get_preferred_label)
-setattr(PropertyClass, 'get_parents', get_parents)
-setattr(PropertyClass, 'get_annotations', get_property_annotations)
-
-setattr(Restriction, 'get_typename', get_typename)
-
 setattr(Namespace, '__init__', namespace_init)
 
-# Method names for individuals must be different from method names for classes
-type.__setattr__(Thing, 'get_preflabel', get_preferred_label)
-type.__setattr__(Thing, 'get_individual_annotations',
-                 get_individual_annotations)
+
+#
+# Extending Metadata
+#
+def keys(self):
+    """Return a generator over annotation property names associates
+    with this ontology."""
+    ns = self.namespace
+    for a in ns.annotation_properties():
+        if ns._has_data_triple_spod(s=ns.storid, p=a.storid):
+            yield a
+
+def items(self):
+    """Return a generator over annotation property (name, value_list)
+    pairs associates with this ontology."""
+    ns = self.namespace
+    for a in ns.annotation_properties():
+        if ns._has_data_triple_spod(s=ns.storid, p=a.storid):
+            yield a, self.__getattr__(a.name)
+
+def has(self, name):
+    """Returns true if `name`"""
+    return name in set(self.keys())
+
+def __contains__(self, name):
+    return self.has(name)
+
+def __iter__(self):
+    return self.keys()
+
+def __setattr__(self, attr, values):
+    metadata__setattr__save(self, attr, values)
+    # Make sure that __setattr__() also updates the triplestore
+    lst = self.__dict__[attr]
+    if lst:
+        ns = self.namespace
+        annot = {
+            a.name: a for a in owlready2.AnnotationProperty.__subclasses__()}
+        if attr in annot:
+            prop = annot[attr]
+        else:
+            with ns.ontology:
+                prop = types.new_class(attr, (owlready2.AnnotationProperty, ))
+        o, d = owlready2.to_literal(lst[0])
+        ns._set_data_triple_spod(ns.storid, prop.storid, o, d)
+        for e in lst[1:]:
+            o, d = owlready2.to_literal(e)
+            ns._set_data_triple_spod(ns.storid, prop.storid, o, d)
+
+def __repr__(self):
+    s = ['Metadata(']
+    for a, values in self.items():
+        sep = '\n' + ' ' * (len(a.name) + 4)
+        s.append('  %s=[%s],' % (a.name, sep.join(repr(v) for v in values)))
+    s.append(')')
+    return '\n'.join(s)
+
+
+metadata__setattr__save = Metadata.__setattr__
+setattr(Metadata, 'keys', keys)
+setattr(Metadata, 'items', items)
+setattr(Metadata, 'has', has)
+setattr(Metadata, '__contains__', __contains__)
+setattr(Metadata, '__iter__', __iter__)
+setattr(Metadata, '__setattr__', __setattr__)
+setattr(Metadata, '__repr__', __repr__)
+Metadata.__getitem__ = Metadata.__getattr__
+Metadata.__setitem__ = Metadata.__setattr__

--- a/emmo/patch.py
+++ b/emmo/patch.py
@@ -5,7 +5,6 @@ import types
 import owlready2
 from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
 from owlready2 import Metadata
-from owlready2 import rdf_type, owl_annotation_property
 
 
 # Improve default rendering of entities
@@ -26,7 +25,7 @@ owlready2.set_render_func(render_func)
 
 #
 # Extending ThingClass (classes)
-#
+# ==============================
 def get_preferred_label(self):
     """Returns the preferred label as a string (not list).
 
@@ -131,7 +130,7 @@ setattr(ThingClass, 'get_indirect_is_a', get_indirect_is_a)
 
 #
 # Extending PropertyClass (properties)
-#
+# ====================================
 def get_property_annotations(self, all=False, imported=True):
     """Returns a dict with non-empty property annotations.
 
@@ -156,7 +155,7 @@ setattr(PropertyClass, 'get_annotations', get_property_annotations)
 
 #
 # Extending Thing (individuals)
-#
+# =============================
 def get_individual_annotations(self, all=False, imported=True):
     """Returns a dict with non-empty individual annotations.
 
@@ -182,16 +181,17 @@ type.__setattr__(Thing, 'get_individual_annotations',
 
 #
 # Extending Restriction
-#
+# =====================
 def get_typename(self):
     return owlready2.class_construct._restriction_type_2_label[self.type]
+
 
 setattr(Restriction, 'get_typename', get_typename)
 
 
 #
 # Extending Namespace
-#
+# ===================
 orig_namespace_init = Namespace.__init__
 
 
@@ -200,12 +200,13 @@ def namespace_init(self, world_or_ontology, base_iri, name=None):
     if self.name.endswith('.ttl'):
         self.name = self.name[:-4]
 
+
 setattr(Namespace, '__init__', namespace_init)
 
 
 #
 # Extending Metadata
-#
+# ==================
 def keys(self):
     """Return a generator over annotation property names associates
     with this ontology."""
@@ -213,6 +214,7 @@ def keys(self):
     for a in ns.annotation_properties():
         if ns._has_data_triple_spod(s=ns.storid, p=a.storid):
             yield a
+
 
 def items(self):
     """Return a generator over annotation property (name, value_list)
@@ -222,15 +224,19 @@ def items(self):
         if ns._has_data_triple_spod(s=ns.storid, p=a.storid):
             yield a, self.__getattr__(a.name)
 
+
 def has(self, name):
     """Returns true if `name`"""
     return name in set(self.keys())
 
+
 def __contains__(self, name):
     return self.has(name)
 
+
 def __iter__(self):
     return self.keys()
+
 
 def __setattr__(self, attr, values):
     metadata__setattr__save(self, attr, values)
@@ -250,6 +256,7 @@ def __setattr__(self, attr, values):
         for e in lst[1:]:
             o, d = owlready2.to_literal(e)
             ns._set_data_triple_spod(ns.storid, prop.storid, o, d)
+
 
 def __repr__(self):
     s = ['Metadata(']


### PR DESCRIPTION
Added some new features (used for generating the cif ontology):
  - save to turtle and other formats supported by rdflib
  - added more methods to ontology metadata: keys(), items(), ++
  - implemented annotate_with_ontology() utility function