### PR TITLE
Made it possible to load other ontologies like foaf

### DIFF
--- a/emmo/ontology.py
+++ b/emmo/ontology.py
@@ -299,7 +299,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
                    tmpdir=tmpdir, **kwargs)
 
         # Enable optimised search by get_by_label()
-        if not self._special_labels:
+        if self._special_labels is None:
             for iri in DEFAULT_LABEL_ANNOTATIONS:
                 self.add_label_annotation(iri)
             t = self.world['http://www.w3.org/2002/07/owl#topObjectProperty']

--- a/emmo/tests/test_import_foaf.py
+++ b/emmo/tests/test_import_foaf.py
@@ -1,0 +1,26 @@
+# Test importing foaf
+#
+# This test serves more like an example
+
+from emmo import get_ontology
+
+skos = get_ontology('http://www.w3.org/2004/02/skos/core#').load()
+foaf = get_ontology("http://xmlns.com/foaf/0.1/")
+
+# Needed since foaf refer to skos without importing it
+foaf.imported_ontologies.append(skos)
+
+# Turn off label lookup.  Needed because foaf uses labels that are not
+# valid Python identifiers
+foaf._special_labels = ()
+
+# Now we can load foaf
+foaf.load()
+
+
+emmo = get_ontology().load()
+
+with emmo:
+
+    class Person(emmo.Interpreter):
+        equivalent_to = [foaf.Person]


### PR DESCRIPTION
Common ontologies where we refer to entities by name rather than skos:prefLabel or rdfs:label are badly supported by EMMO-python. This PR make it possible to load foaf:

```python
from emmo import get_ontology
skos = get_ontology('http://www.w3.org/2004/02/skos/core#').load()
foaf = get_ontology("http://xmlns.com/foaf/0.1/")
foaf.imported_ontologies.append(skos)
foaf._special_labels = ()  # <-- needed to not get confused by labels containing spaces, not convenient!
foaf.load()

emmo = get_ontology().load()

with emmo:
    class Person(emmo.Interpreter):
        equivalent_to = [foaf.Person]
```

We should think about a more convenient solution

