### PR TITLE
Remove sub-fact++ modules importability

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -42,7 +42,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest
-        sudo apt-get install -y graphviz
+        sudo apt-get install -y graphviz openjdk-11-jre-headless
 
     - name: Install EMMOntoPy
       run: python setup.py install

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,5 @@ recursive-exclude examples/emmodoc old/** genfigs/** *.pdf *.html *~
 
 recursive-include demo *
 recursive-exclude demo old __pycache__ *~ *.pyc *.off
+
+recursive-include emmo/factpluspluswrapper/java *

--- a/ontopy/factpluspluswrapper/factppgraph.py
+++ b/ontopy/factpluspluswrapper/factppgraph.py
@@ -84,7 +84,7 @@ class FaCTPPGraph:
         """
         inferred = self.inferred
         for k, v in self.namespaces.items():
-            inferred.bind(k, v, override=True, replace=True)
+            inferred.namespace_manager.bind(k, v, override=True, replace=True)
 
     def clean_base(self):
         """Remove all relations `s? a owl:Ontology` where `s?` is not

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setuptools.setup(
         'ontopy.factpluspluswrapper.java.lib.jars': ['*.jar'],
         'ontopy.factpluspluswrapper.java': ['pom.xml'],
     },
+    include_package_data=True,
     data_files=[
         ('share/EMMO-python', ['README.md', 'LICENSE.txt']),
         (

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,7 +13,7 @@ def test_basic() -> None:
 
     emmo = get_ontology()
     emmo.load()
-    # emmo.sync_reasoner()
+    emmo.sync_reasoner()
 
 
     onto = get_ontology('onto.owl')


### PR DESCRIPTION
I.e., remove them as Python importable modules.
Ensure all files are still included in the package build.

Closes #213.

Note, this is a remake of #214, but using a branch from this repository instead of a fork.