### PR TITLE
Changed EMMO to be acronym for Elemental Multiperspective Material Ontology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EMMO - Python API for the European Materials & Modelling Ontology
+# EMMO - Python API for the Elemental Multiperspective Material Ontology
 
 <!-- markdownlint-disable MD033 -->
 
@@ -8,7 +8,7 @@
 This package is based on [Owlready2] and provides an intuitive representation of [EMMO] in Python.
 It is available on [GitHub][EMMOntoPy] and on [PyPI][PyPI:EMMO] under the open source [BSD 3-Clause license](LICENSE.txt).
 
-The European Materials & Modelling Ontology (EMMO) is an ongoing effort to create an ontology that takes into account fundamental concepts of physics, chemistry and materials science and is designed to pave the road for semantic interoperability.
+The Elemental Multiperspective Material Ontology (EMMO) is an ongoing effort to create an ontology that takes into account fundamental concepts of physics, chemistry and materials science and is designed to pave the road for semantic interoperability.
 The aim of EMMO is to be generic and provide a common ground for describing materials, models and data that can be adapted by all domains.
 
 EMMO is formulated using OWL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# EMMO - Python API for the European Materials & Modelling Ontology
+# EMMO - Python API for the Elemental Multiperspective Material Ontology
 
 <!-- markdownlint-disable MD033 -->
 
@@ -8,7 +8,7 @@
 This package is based on [Owlready2] and provides an intuitive representation of [EMMO] in Python.
 It is available on [GitHub][EMMOntoPy] and on [PyPI][PyPI:EMMO] under the open source [BSD 3-Clause license](LICENSE.md).
 
-The European Materials & Modelling Ontology (EMMO) is an ongoing effort to create an ontology that takes into account fundamental concepts of physics, chemistry and materials science and is designed to pave the road for semantic interoperability.
+The Elemental Multiperspective Material Ontology (EMMO) is an ongoing effort to create an ontology that takes into account fundamental concepts of physics, chemistry and materials science and is designed to pave the road for semantic interoperability.
 The aim of EMMO is to be generic and provide a common ground for describing materials, models and data that can be adapted by all domains.
 
 EMMO is formulated using OWL.

--- a/examples/emmodoc/emmodoc-meta.yaml
+++ b/examples/emmodoc/emmodoc-meta.yaml
@@ -16,7 +16,7 @@ institute: 'European Materials Modelling Counsil (EMMC)'
 keywords: [EMMO, 'materials science', modelling, characterisation, materials, ontology]
 abstract: |
   EMMO is an ontology that is created by the
-  <a href="https://emmc.info/">Europeean Materials Modelling Council
+  <a href="https://emmc.info/">European Materials Modelling Council
   (EMMC)</a> to provide a formal way to describe the fundamental
   concepts of physics, chemistry and materials science. EMMO is
   designed to pave the road for semantic interoperability providing a

--- a/examples/emmodoc/emmodoc-meta.yaml
+++ b/examples/emmodoc/emmodoc-meta.yaml
@@ -1,5 +1,5 @@
 ---
-title:  'Europeean Materials Modelling Ontology'
+title:  'Elemental Multiperspective Material Ontology'
 version: 1.0.0-alpha2
 author:
 - name: Emanuele Ghedini

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Python reference API for the Europeean Materials & Modelling Ontology (EMMO).
+Python reference API for the Elementary Multiperspective Material Ontology (EMMO).
 """
 import os
 import re
@@ -62,8 +62,8 @@ setuptools.setup(
     version=VERSION,
     author='Jesper Friis, Francesca Lønstad Bleken, Bjørn Tore Løvfall',
     author_email='jesper.friis@sintef.no',
-    description=('Python reference API for the Europeean Materials & '
-                 'Modelling Ontology'),
+    description=('Python reference API for the Elementary Multiperspective'
+                 'Material Ontology'),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/emmo-repo/EMMO-python',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Python reference API for the Elementary Multiperspective Material Ontology (EMMO).
+Python reference API for the
+Elementary Multiperspective Material Ontology (EMMO).
 """
 import os
 import re


### PR DESCRIPTION
Closes #230, 
EMMO i sno longer acronym for European Materials & Modeling Ontology, but is changed to 
Elemental Multiperspective Material Ontology.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [x] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand? 
- [ ] Are comments for humans to read, not computers to disregard? 
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [x] Has the documentation been updated as necessary?
- [x] Does this close the issue?
- [x] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
Only a small change in README.md
