### PR TITLE
Import from `collections.abc` when possible

### DIFF
--- a/demo/horizontal/emmo2meta.py
+++ b/demo/horizontal/emmo2meta.py
@@ -29,7 +29,7 @@ import owlready2
 if sys.version_info >= (3, 7):
     odict = dict
 else:
-    from collections.abc import OrderedDict as odict  # noqa: F401
+    from collections import OrderedDict as odict  # noqa: F401
 
 
 class EMMO2Meta:

--- a/demo/horizontal/emmo2meta.py
+++ b/demo/horizontal/emmo2meta.py
@@ -29,7 +29,7 @@ import owlready2
 if sys.version_info >= (3, 7):
     odict = dict
 else:
-    from collections import OrderedDict as odict  # noqa: F401
+    from collections.abc import OrderedDict as odict  # noqa: F401
 
 
 class EMMO2Meta:

--- a/ontopy/factpluspluswrapper/sync_factpp.py
+++ b/ontopy/factpluspluswrapper/sync_factpp.py
@@ -1,4 +1,5 @@
-import collections
+from collections import defaultdict
+from collections.abc import Sequence
 
 import rdflib
 from rdflib import URIRef, RDF, RDFS, OWL
@@ -39,7 +40,7 @@ def sync_reasoner_factpp(ontology_or_world=None, infer_property_values=False,
         world = ontology_or_world
     elif isinstance(ontology_or_world, Ontology):
         world = ontology_or_world.world
-    elif isinstance(ontology_or_world, collections.Sequence):
+    elif isinstance(ontology_or_world, Sequence):
         world = ontology_or_world[0].world
     else:
         world = owlready2.default_world
@@ -70,8 +71,8 @@ def sync_reasoner_factpp(ontology_or_world=None, infer_property_values=False,
         print('*** Load inferred ontology')
         # Check all rdfs:subClassOf relations in the inferred graph and add
         # them to the world if they are missing
-        new_parents = collections.defaultdict(list)
-        new_equivs = collections.defaultdict(list)
+        new_parents = defaultdict(list)
+        new_equivs = defaultdict(list)
         entity_2_type = {}
 
         for s, p, o in g2.triples((None, None, None)):

--- a/ontopy/nadict.py
+++ b/ontopy/nadict.py
@@ -4,7 +4,7 @@ A nested dict with both attribute and item access.
 
 NA stands for Nested and Attribute.
 """
-import collections
+from collections.abc import Mapping
 import copy
 
 
@@ -66,7 +66,7 @@ class NADict:
             else:
                 self._dict[key] = value
         else:
-            if isinstance(value, collections.abc.Mapping):
+            if isinstance(value, Mapping):
                 self._dict[key] = NADict(value)
             else:
                 self._dict[key] = value


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #236.

Importing ABCs from collections is deprecated and will be removed in Python 3.10.

As a note, I ran `pytest` and checked the resulting Python warnings. The only ones left are `DeprecationWarning`s the package raises itself.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
