### PR TITLE
Added Standard methods to Ontology

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -211,10 +211,8 @@ class Ontology(owlready2.Ontology, OntoGraph):
             if isinstance(i, int):
                 if i >= 0:
                     return self._unabbreviate(i)
-                else:
-                    return "_:"  # blank nodes are given random neg. storid
-            else:
-                return i
+                return "_:"  # blank nodes are given random neg. storid
+            return i
 
         for s, p, o in self.world.get_triples():
             s = _unabbreviate(s)

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -216,7 +216,9 @@ class Ontology(owlready2.Ontology, OntoGraph):
             return i
 
         for subject, predicate, obj in self.world.get_triples():
-            yield _unabbreviate(subject), _unabbreviate(predicate), _unabbreviate(obj)
+            yield (_unabbreviate(subject),
+                   _unabbreviate(predicate),
+                   _unabbreviate(obj))
 
     def get_by_label(self, label, label_annotations=None, namespace=None):
         """Returns entity with label annotation `label`.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -190,6 +190,26 @@ class Ontology(owlready2.Ontology, OntoGraph):
         # Play nice with inspect...
         pass
 
+    def __eq__(self, other):
+        return self.__hash__() == other.__hash__()
+
+    def __str__(self):
+        """TODO"""
+
+    def __iter__(self):
+        """TODO"""
+
+    def __delitem__(self):
+        """TODO"""
+
+    def __setitem__(self, key, value):
+        """ MAYBE TODO """
+        # self[key] = value
+        # emmo['HAtom'] = emmo.Atom
+
+    def __hash__(self):
+        return hash((self.base_iri, self.get_entities()))
+
     def get_by_label(self, label, label_annotations=None, namespace=None):
         """Returns entity with label annotation `label`.
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -215,11 +215,8 @@ class Ontology(owlready2.Ontology, OntoGraph):
                 return "_:"  # blank nodes are given random neg. storid
             return i
 
-        for s, p, o in self.world.get_triples():
-            s = _unabbreviate(s)
-            p = _unabbreviate(p)
-            o = _unabbreviate(o)
-            yield s, p, o
+        for subject, predicate, obj in self.world.get_triples():
+            yield _unabbreviate(subject), _unabbreviate(predicate), _unabbreviate(obj)
 
     def get_by_label(self, label, label_annotations=None, namespace=None):
         """Returns entity with label annotation `label`.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -220,8 +220,8 @@ class Ontology(owlready2.Ontology, OntoGraph):
             self.get_entities(imported=True,
                               classes=True,
                               individuals=False,
-                              object_properties=False,
-                              data_properties=False,
+                              object_properties=True,
+                              data_properties=True,
                               annotation_properties=False,
                               ), key=lambda e: e.iri)
         return hash((self.base_iri, tuple(sorted_entities)))

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -204,14 +204,6 @@ class Ontology(owlready2.Ontology, OntoGraph):
         """
         return set(self.get_triples()) == set(other.get_triples())
 
-    def _sorted_entities(self):
-        """Return sorted entities
-        """
-        return sorted(e.iri for e in self.get_entities(
-                imported=True, classes=True,
-                individuals=True, object_properties=True,
-                data_properties=True, annotation_properties=True))
-
     def get_triples(self):
         """ Returns all triples unabbreviated
         """

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -200,7 +200,8 @@ class Ontology(owlready2.Ontology, OntoGraph):
         """Checks if this ontology is equal to other.
 
         Equality of all triples obtained from self.get_triples(),
-        i.e. all triples except blank nodes.
+        i.e. blank nodes are not distinguished, but relations
+        to blank nodes are included.
         """
         return set(self.get_triples()) == set(other.get_triples())
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -112,6 +112,9 @@ class World(owlready2.World):
 
         return onto
 
+    def __hash__(self):
+        return hash(self.filename)
+
 
 class Ontology(owlready2.Ontology, OntoGraph):
     """A generic class extending owlready2.Ontology.
@@ -191,7 +194,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
         pass
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        return hash(self) == hash(other)
 
     def __str__(self):
         """TODO"""
@@ -208,7 +211,15 @@ class Ontology(owlready2.Ontology, OntoGraph):
         # emmo['HAtom'] = emmo.Atom
 
     def __hash__(self):
-        return hash((self.base_iri, self.get_entities()))
+        sorted_entities = sorted(
+            self.get_entities(imported=True,
+                              classes=True,
+                              individuals=False,
+                              object_properties=False,
+                              data_properties=False,
+                              annotation_properties=False,
+                             ), key=lambda e: e.name)
+        return hash((self.base_iri, tuple(sorted_entities)))
 
     def get_by_label(self, label, label_annotations=None, namespace=None):
         """Returns entity with label annotation `label`.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -223,7 +223,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
                               object_properties=False,
                               data_properties=False,
                               annotation_properties=False,
-                             ), key=lambda e: e.iri)
+                              ), key=lambda e: e.iri)
         return hash((self.base_iri, tuple(sorted_entities)))
 
     def get_by_label(self, label, label_annotations=None, namespace=None):

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -211,6 +211,11 @@ class Ontology(owlready2.Ontology, OntoGraph):
         # emmo['HAtom'] = emmo.Atom
 
     def __hash__(self):
+        """Returns hash.
+
+        Note that entities must have iris for this to work, since entities are
+        sorted by their iris before creating the hash.
+        """
         sorted_entities = sorted(
             self.get_entities(imported=True,
                               classes=True,
@@ -218,7 +223,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
                               object_properties=False,
                               data_properties=False,
                               annotation_properties=False,
-                             ), key=lambda e: e.name)
+                             ), key=lambda e: e.iri)
         return hash((self.base_iri, tuple(sorted_entities)))
 
     def get_by_label(self, label, label_annotations=None, namespace=None):

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -3,7 +3,7 @@
 import types
 
 import owlready2
-from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
+from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace, EntityClass
 from owlready2 import Metadata
 
 
@@ -67,6 +67,16 @@ def _dir(self):
     s.update(props)
     return sorted(s)
 
+def _hash(self):
+    """Define hash of ThingClass and PropertyClass."""
+    try:
+        return hash(self.iri)
+    except AttributeError:
+        return hash(self.name)
+
+def _eq(self, other):
+    """Define equality based on hash for ThingClass and PropertyClass."""
+    return hash(self) == hash(other)
 
 def _hash(self):
     """Define hash of ThingClass and PropertyClass."""
@@ -157,7 +167,6 @@ def get_property_annotations(self, all=False, imported=True):
         return d
     else:
         return {k: v for k, v in d.items() if v}
-
 
 setattr(PropertyClass, '__hash__', _hash)
 # setattr(PropertyClass, '__eq__', _eq)

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -3,7 +3,7 @@
 import types
 
 import owlready2
-from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace, EntityClass
+from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
 from owlready2 import Metadata
 
 
@@ -67,20 +67,11 @@ def _dir(self):
     s.update(props)
     return sorted(s)
 
-def _hash(self):
-    """Define hash of ThingClass and PropertyClass."""
-    try:
-        return hash(self.iri)
-    except AttributeError:
-        return hash(self.name)
-
-def _eq(self, other):
-    """Define equality based on hash for ThingClass and PropertyClass."""
-    return hash(self) == hash(other)
 
 def _hash(self):
     """Define hash of ThingClass and PropertyClass."""
     return hash(self.iri)
+
 
 def _eq(self, other):
     """Define equality based on hash for ThingClass and PropertyClass."""
@@ -167,6 +158,7 @@ def get_property_annotations(self, all=False, imported=True):
         return d
     else:
         return {k: v for k, v in d.items() if v}
+
 
 setattr(PropertyClass, '__hash__', _hash)
 # setattr(PropertyClass, '__eq__', _eq)

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -70,17 +70,7 @@ def _dir(self):
 
 def _hash(self):
     """Define hash of ThingClass and PropertyClass."""
-    try:
-        return hash(self.iri)
-    except AttributeError:
-        try:
-            return hash(self.prefLabel)
-        except AttributeError:
-            try:
-                return hash(self.name)
-            except AttributeError:
-                return hash(self.label)
-
+    return hash(self.iri)
 
 def _eq(self, other):
     """Define equality based on hash for ThingClass and PropertyClass."""

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -3,7 +3,7 @@
 import types
 
 import owlready2
-from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace, EntityClass
+from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
 from owlready2 import Metadata
 
 
@@ -67,16 +67,25 @@ def _dir(self):
     s.update(props)
     return sorted(s)
 
+
 def _hash(self):
     """Define hash of ThingClass and PropertyClass."""
     try:
         return hash(self.iri)
     except AttributeError:
-        return hash(self.name)
+        try:
+            return hash(self.prefLabel)
+        except AttributeError:
+            try:
+                return hash(self.name)
+            except AttributeError:
+                return hash(self.label)
+
 
 def _eq(self, other):
     """Define equality based on hash for ThingClass and PropertyClass."""
     return hash(self) == hash(other)
+
 
 def get_class_annotations(self, all=False, imported=True):
     """Returns a dict with non-empty annotations.
@@ -159,8 +168,9 @@ def get_property_annotations(self, all=False, imported=True):
     else:
         return {k: v for k, v in d.items() if v}
 
+
 setattr(PropertyClass, '__hash__', _hash)
-#setattr(PropertyClass, '__eq__', _eq)
+# setattr(PropertyClass, '__eq__', _eq)
 setattr(PropertyClass, 'get_preferred_label', get_preferred_label)
 setattr(PropertyClass, 'get_parents', get_parents)
 setattr(PropertyClass, 'get_annotations', get_property_annotations)

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -3,7 +3,7 @@
 import types
 
 import owlready2
-from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace
+from owlready2 import ThingClass, PropertyClass, Thing, Restriction, Namespace, EntityClass
 from owlready2 import Metadata
 
 
@@ -67,6 +67,16 @@ def _dir(self):
     s.update(props)
     return sorted(s)
 
+def _hash(self):
+    """Define hash of ThingClass and PropertyClass."""
+    try:
+        return hash(self.iri)
+    except AttributeError:
+        return hash(self.name)
+
+def _eq(self, other):
+    """Define equality based on hash for ThingClass and PropertyClass."""
+    return hash(self) == hash(other)
 
 def get_class_annotations(self, all=False, imported=True):
     """Returns a dict with non-empty annotations.
@@ -121,6 +131,8 @@ def get_indirect_is_a(self, skip_classes=True):
 
 # Inject methods into ThingClass
 setattr(ThingClass, '__dir__', _dir)
+setattr(ThingClass, '__hash__', _hash)
+setattr(ThingClass, '__eq__', _eq)
 setattr(ThingClass, 'get_preferred_label', get_preferred_label)
 setattr(ThingClass, 'get_parents', get_parents)
 setattr(ThingClass, 'get_annotations', get_class_annotations)
@@ -147,7 +159,8 @@ def get_property_annotations(self, all=False, imported=True):
     else:
         return {k: v for k, v in d.items() if v}
 
-
+setattr(PropertyClass, '__hash__', _hash)
+#setattr(PropertyClass, '__eq__', _eq)
 setattr(PropertyClass, 'get_preferred_label', get_preferred_label)
 setattr(PropertyClass, 'get_parents', get_parents)
 setattr(PropertyClass, 'get_annotations', get_property_annotations)

--- a/ontopy/patch.py
+++ b/ontopy/patch.py
@@ -68,16 +68,6 @@ def _dir(self):
     return sorted(s)
 
 
-def _hash(self):
-    """Define hash of ThingClass and PropertyClass."""
-    return hash(self.iri)
-
-
-def _eq(self, other):
-    """Define equality based on hash for ThingClass and PropertyClass."""
-    return hash(self) == hash(other)
-
-
 def get_class_annotations(self, all=False, imported=True):
     """Returns a dict with non-empty annotations.
 
@@ -131,8 +121,6 @@ def get_indirect_is_a(self, skip_classes=True):
 
 # Inject methods into ThingClass
 setattr(ThingClass, '__dir__', _dir)
-setattr(ThingClass, '__hash__', _hash)
-setattr(ThingClass, '__eq__', _eq)
 setattr(ThingClass, 'get_preferred_label', get_preferred_label)
 setattr(ThingClass, 'get_parents', get_parents)
 setattr(ThingClass, 'get_annotations', get_class_annotations)
@@ -160,8 +148,6 @@ def get_property_annotations(self, all=False, imported=True):
         return {k: v for k, v in d.items() if v}
 
 
-setattr(PropertyClass, '__hash__', _hash)
-# setattr(PropertyClass, '__eq__', _eq)
 setattr(PropertyClass, 'get_preferred_label', get_preferred_label)
 setattr(PropertyClass, 'get_parents', get_parents)
 setattr(PropertyClass, 'get_annotations', get_property_annotations)

--- a/tests/test_load_emmo.py
+++ b/tests/test_load_emmo.py
@@ -17,5 +17,5 @@ def test_load_emmo() -> None:
 
     EMMO_inferred.new_entity('HydrogenAtom', EMMO_inferred.Atom)
     EMMO_inferred.sync_attributes()
-    #assert EMMO_inferred != get_emmo(None)
+    assert EMMO_inferred != get_emmo(None)
 

--- a/tests/test_load_emmo.py
+++ b/tests/test_load_emmo.py
@@ -18,4 +18,3 @@ def test_load_emmo() -> None:
     EMMO_inferred.new_entity('HydrogenAtom', EMMO_inferred.Atom)
     EMMO_inferred.sync_attributes()
     assert EMMO_inferred != get_emmo(None)
-

--- a/tests/test_load_emmo.py
+++ b/tests/test_load_emmo.py
@@ -7,19 +7,20 @@ def test_load_emmo() -> None:
     from emmopy import get_emmo
 
     EMMO_inferred = get_emmo()
-    EMMO_inf = get_emmo(None)
+    EMMO_inferred_again = get_emmo(None)
     EMMO = get_emmo(inferred=False)
 
     assert EMMO_inferred
+    assert EMMO_inferred_again
     assert EMMO
 
-    assert EMMO_inferred == EMMO_inf
+    assert EMMO_inferred == EMMO_inferred_again
     assert EMMO != EMMO_inferred
 
     EMMO_inferred.new_entity('HydrogenAtom', EMMO_inferred.Atom)
     EMMO_inferred.sync_attributes()
-    assert EMMO_inferred != EMMO_inf
+    assert EMMO_inferred != EMMO_inferred_again
 
     EMMO_inferred2 = get_emmo()
     EMMO_inferred2.Atom.comment.append('New triple')
-    assert EMMO_inferred2 != EMMO_inf
+    assert EMMO_inferred2 != EMMO_inferred_again

--- a/tests/test_load_emmo.py
+++ b/tests/test_load_emmo.py
@@ -12,5 +12,10 @@ def test_load_emmo() -> None:
     assert EMMO_inferred
     assert EMMO
 
-    assert EMMO_inferred.base_iri == get_emmo(None).base_iri
+    assert EMMO_inferred == get_emmo(None)
+    assert EMMO != EMMO_inferred
+
+    EMMO_inferred.new_entity('HydrogenAtom', EMMO_inferred.Atom)
+    EMMO_inferred.sync_attributes()
+    #assert EMMO_inferred != get_emmo(None)
 

--- a/tests/test_load_emmo.py
+++ b/tests/test_load_emmo.py
@@ -7,14 +7,19 @@ def test_load_emmo() -> None:
     from emmopy import get_emmo
 
     EMMO_inferred = get_emmo()
+    EMMO_inf = get_emmo(None)
     EMMO = get_emmo(inferred=False)
 
     assert EMMO_inferred
     assert EMMO
 
-    assert EMMO_inferred == get_emmo(None)
+    assert EMMO_inferred == EMMO_inf
     assert EMMO != EMMO_inferred
 
     EMMO_inferred.new_entity('HydrogenAtom', EMMO_inferred.Atom)
     EMMO_inferred.sync_attributes()
-    assert EMMO_inferred != get_emmo(None)
+    assert EMMO_inferred != EMMO_inf
+
+    EMMO_inferred2 = get_emmo()
+    EMMO_inferred2.Atom.comment.append('New triple')
+    assert EMMO_inferred2 != EMMO_inf


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Closes #228.

__hash__ (based on base_iri) defined for ontology.Ontology (only req to allow for __eq__ implementation)

__eq__  (based on all triples) defined for ontology.Ontology. Note that consistency between blank nodes is not checked.

This is tested in test_load_emmo.py.
The test also checks that two equal emmo-ontologies are no longer equal when a new class  or new relation is added to one of them.


## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
