### PR TITLE
Update method name to avoid overwriting inherited

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -203,7 +203,9 @@ class Ontology(owlready2.Ontology, OntoGraph):
         i.e. blank nodes are not distinguished, but relations
         to blank nodes are included.
         """
-        return set(self.get_unabbreviated_triples()) == set(other.get_unabbreviated_triples())
+        return set(self.get_unabbreviated_triples()) == set(
+            other.get_unabbreviated_triples()
+        )
 
     def get_unabbreviated_triples(self):
         """ Returns all triples unabbreviated

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -199,13 +199,13 @@ class Ontology(owlready2.Ontology, OntoGraph):
     def __eq__(self, other):
         """Checks if this ontology is equal to other.
 
-        Equality of all triples obtained from self.get_triples(),
+        Equality of all triples obtained from self.get_unabbreviated_triples(),
         i.e. blank nodes are not distinguished, but relations
         to blank nodes are included.
         """
-        return set(self.get_triples()) == set(other.get_triples())
+        return set(self.get_unabbreviated_triples()) == set(other.get_unabbreviated_triples())
 
-    def get_triples(self):
+    def get_unabbreviated_triples(self):
         """ Returns all triples unabbreviated
         """
         def _unabbreviate(i):

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -215,7 +215,7 @@ class Ontology(owlready2.Ontology, OntoGraph):
                 return "_:"  # blank nodes are given random neg. storid
             return i
 
-        for subject, predicate, obj in self.world.get_triples():
+        for subject, predicate, obj in self.get_triples():
             yield (_unabbreviate(subject),
                    _unabbreviate(predicate),
                    _unabbreviate(obj))


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #280 

Rename `ontopy.ontology.Ontology.get_triples()` to
`get_unabbreviated_triples()` to avoid overwriting the inherited
`get_triples()` method.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
