### PR TITLE
Improved representation of blank nodes

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -52,6 +52,27 @@ DEFAULT_LABEL_ANNOTATIONS = [
 ]
 
 
+class BNode:
+    """Represents a blank node."""
+    def __init__(self, base_iri, storid):
+        if (storid >= 0):
+            raise ValueError(
+                f'bnode is supposed to have a negative storid: {storid}')
+        self.base_iri = base_iri
+        self.storid = storid
+
+    def __repr__(self):
+        return repr(f'_:b{-self.storid}')
+
+    def __hash__(self):
+        return hash((self.base_iri, self.storid))
+
+    def __eq__(self, other):
+        """For now blank nodes always compare true with each other."""
+        print('***', self, other, isinstance(other, BNode))
+        return isinstance(other, BNode)
+
+
 def get_ontology(*args, **kwargs):
     """Returns a new Ontology from `base_iri`.
 
@@ -202,13 +223,13 @@ class Ontology(  # pylint: disable=too-many-public-methods
         pass
 
     def __hash__(self):
-        """Returns hash based on base_iri
+        """Returns a hash based on base_iri.
         This is done to keep Ontology hashable when defining __eq__.
         """
         return hash(self.base_iri)
 
     def __eq__(self, other):
-        """Checks if this ontology is equal to other.
+        """Checks if this ontology is equal to `other`.
 
         Equality of all triples obtained from self.get_unabbreviated_triples(),
         i.e. blank nodes are not distinguished, but relations
@@ -219,13 +240,15 @@ class Ontology(  # pylint: disable=too-many-public-methods
         )
 
     def get_unabbreviated_triples(self):
-        """Returns all triples unabbreviated"""
+        """Returns all triples unabbreviated."""
 
         def _unabbreviate(i):
             if isinstance(i, int):
                 if i >= 0:
                     return self._unabbreviate(i)
-                return "_:"  # blank nodes are given random neg. storid
+                # negative storid corresponds to blank nodes
+                #return '_:b'
+                return BNode(self.base_iri, i)
             return i
 
         for subject, predicate, obj in self.get_triples():

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -28,9 +28,11 @@ from owlready2 import locstr
 from owlready2.entity import ThingClass
 
 from ontopy.factpluspluswrapper.sync_factpp import sync_reasoner_factpp
-
-from ontopy.utils import asstring, read_catalog, infer_version, convert_imported
 from ontopy.utils import (
+    asstring,
+    read_catalog,
+    infer_version,
+    convert_imported,
     FMAP,
     IncompatibleVersion,
     isinteractive,
@@ -116,26 +118,26 @@ class World(owlready2.World):
 
         return onto
 
-    def get_unabbreviated_triples(self, bnode=None):
-        """ Returns all triples unabbreviated.
+    def get_unabbreviated_triples(self, label=None):
+        """Returns all triples unabbreviated.
 
-        If `bnode` is given, it will be used to represent blank nodes.
+        If `label` is given, it will be used to represent blank nodes.
         """
+
         def _unabbreviate(i):
             if isinstance(i, int):
                 # negative storid corresponds to blank nodes
                 if i >= 0:
                     return self._unabbreviate(i)
-                elif bnode is None:
-                    return BNode(self, i)
-                else:
-                    return bnode
+                return BlankNode(self, i) if label is None else label
             return i
 
         for subject, predicate, obj in self.get_triples():
-            yield (_unabbreviate(subject),
-                   _unabbreviate(predicate),
-                   _unabbreviate(obj))
+            yield (
+                _unabbreviate(subject),
+                _unabbreviate(predicate),
+                _unabbreviate(obj),
+            )
 
 
 class Ontology(  # pylint: disable=too-many-public-methods
@@ -232,20 +234,20 @@ class Ontology(  # pylint: disable=too-many-public-methods
         """Checks if this ontology is equal to `other`.
 
         This function compares the result of
-        ``set(self.get_unabbreviated_triples(bnode='_:b'))``,
+        ``set(self.get_unabbreviated_triples(label='_:b'))``,
         i.e. blank nodes are not distinguished, but relations to blank
         nodes are included.
         """
-        return set(self.get_unabbreviated_triples(bnode='_:b')) == set(
-            other.get_unabbreviated_triples(bnode='_:b')
+        return set(self.get_unabbreviated_triples(label="_:b")) == set(
+            other.get_unabbreviated_triples(label="_:b")
         )
 
-    def get_unabbreviated_triples(self, bnode=None):
-        """ Returns all triples unabbreviated.
+    def get_unabbreviated_triples(self, label=None):
+        """Returns all triples unabbreviated.
 
-        If `bnode` is given, it will be used to represent blank nodes.
+        If `label` is given, it will be used to represent blank nodes.
         """
-        return World.get_unabbreviated_triples(self, bnode)
+        return World.get_unabbreviated_triples(self, label)
 
     def get_by_label(
         self, label, label_annotations=None, namespace=None
@@ -1273,29 +1275,34 @@ class Ontology(  # pylint: disable=too-many-public-methods
         return entity
 
 
-class BNode:
-    """Represents a blank node."""
-    def __init__(self,
-                 onto: Union[World, Ontology],
-                 storid: int):
+class BlankNode:
+    """Represents a blank node.
+
+    A blank node is a node that is not a literal and has no IRI.
+    Resources represented by blank nodes are also called anonumous resources.
+    Only the subject or object in an RDF triple can be a blank node.
+    """
+
+    def __init__(self, onto: Union[World, Ontology], storid: int):
         """Initiate a blank node.
 
         Args:
             onto: Ontology or World instance.
             storid: The storage id of the blank node.
         """
-        if (storid >= 0):
+        if storid >= 0:
             raise ValueError(
-                f'bnode is supposed to have a negative storid: {storid}')
+                f"A BlankNode is supposed to have a negative storid: {storid}"
+            )
         self.onto = onto
         self.storid = storid
 
     def __repr__(self):
-        return repr(f'_:b{-self.storid}')
+        return repr(f"_:b{-self.storid}")
 
     def __hash__(self):
         return hash((self.onto, self.storid))
 
     def __eq__(self, other):
         """For now blank nodes always compare true against each other."""
-        return isinstance(other, BNode)
+        return isinstance(other, BlankNode)

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1274,15 +1274,16 @@ class Ontology(  # pylint: disable=too-many-public-methods
 
 
 class BNode:
-    """Represents a blank node.
-
-    Args:
-        onto: Ontology or World instance.
-        storid: The storage id of the blank node.
-    """
+    """Represents a blank node."""
     def __init__(self,
                  onto: Union[World, Ontology],
                  storid: int):
+        """Initiate a blank node.
+
+        Args:
+            onto: Ontology or World instance.
+            storid: The storage id of the blank node.
+        """
         if (storid >= 0):
             raise ValueError(
                 f'bnode is supposed to have a negative storid: {storid}')

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -52,27 +52,6 @@ DEFAULT_LABEL_ANNOTATIONS = [
 ]
 
 
-class BNode:
-    """Represents a blank node."""
-    def __init__(self, base_iri, storid):
-        if (storid >= 0):
-            raise ValueError(
-                f'bnode is supposed to have a negative storid: {storid}')
-        self.base_iri = base_iri
-        self.storid = storid
-
-    def __repr__(self):
-        return repr(f'_:b{-self.storid}')
-
-    def __hash__(self):
-        return hash((self.base_iri, self.storid))
-
-    def __eq__(self, other):
-        """For now blank nodes always compare true with each other."""
-        print('***', self, other, isinstance(other, BNode))
-        return isinstance(other, BNode)
-
-
 def get_ontology(*args, **kwargs):
     """Returns a new Ontology from `base_iri`.
 
@@ -136,6 +115,27 @@ class World(owlready2.World):
             onto = Ontology(self, iri)
 
         return onto
+
+    def get_unabbreviated_triples(self, bnode=None):
+        """ Returns all triples unabbreviated.
+
+        If `bnode` is given, it will be used to represent blank nodes.
+        """
+        def _unabbreviate(i):
+            if isinstance(i, int):
+                # negative storid corresponds to blank nodes
+                if i >= 0:
+                    return self._unabbreviate(i)
+                elif bnode is None:
+                    return BNode(self, i)
+                else:
+                    return bnode
+            return i
+
+        for subject, predicate, obj in self.get_triples():
+            yield (_unabbreviate(subject),
+                   _unabbreviate(predicate),
+                   _unabbreviate(obj))
 
 
 class Ontology(  # pylint: disable=too-many-public-methods
@@ -231,32 +231,21 @@ class Ontology(  # pylint: disable=too-many-public-methods
     def __eq__(self, other):
         """Checks if this ontology is equal to `other`.
 
-        Equality of all triples obtained from self.get_unabbreviated_triples(),
-        i.e. blank nodes are not distinguished, but relations
-        to blank nodes are included.
+        This function compares the result of
+        ``set(self.get_unabbreviated_triples(bnode='_:b'))``,
+        i.e. blank nodes are not distinguished, but relations to blank
+        nodes are included.
         """
-        return set(self.get_unabbreviated_triples()) == set(
-            other.get_unabbreviated_triples()
+        return set(self.get_unabbreviated_triples(bnode='_:b')) == set(
+            other.get_unabbreviated_triples(bnode='_:b')
         )
 
-    def get_unabbreviated_triples(self):
-        """Returns all triples unabbreviated."""
+    def get_unabbreviated_triples(self, bnode=None):
+        """ Returns all triples unabbreviated.
 
-        def _unabbreviate(i):
-            if isinstance(i, int):
-                if i >= 0:
-                    return self._unabbreviate(i)
-                # negative storid corresponds to blank nodes
-                #return '_:b'
-                return BNode(self.base_iri, i)
-            return i
-
-        for subject, predicate, obj in self.get_triples():
-            yield (
-                _unabbreviate(subject),
-                _unabbreviate(predicate),
-                _unabbreviate(obj),
-            )
+        If `bnode` is given, it will be used to represent blank nodes.
+        """
+        return World.get_unabbreviated_triples(self, bnode)
 
     def get_by_label(
         self, label, label_annotations=None, namespace=None
@@ -1282,3 +1271,30 @@ class Ontology(  # pylint: disable=too-many-public-methods
         with self:
             entity = types.new_class(name, parents)
         return entity
+
+
+class BNode:
+    """Represents a blank node.
+
+    Args:
+        onto: Ontology or World instance.
+        storid: The storage id of the blank node.
+    """
+    def __init__(self,
+                 onto: Union[World, Ontology],
+                 storid: int):
+        if (storid >= 0):
+            raise ValueError(
+                f'bnode is supposed to have a negative storid: {storid}')
+        self.onto = onto
+        self.storid = storid
+
+    def __repr__(self):
+        return repr(f'_:b{-self.storid}')
+
+    def __hash__(self):
+        return hash((self.onto, self.storid))
+
+    def __eq__(self, other):
+        """For now blank nodes always compare true against each other."""
+        return isinstance(other, BNode)


### PR DESCRIPTION
# Description:
* Changed get_unabbriviated_triples() to represent blank nodes such they can be used for reasoning.
* Has not changed the result of `Ontology.__eq__()`.
* Added get_unabbriviated_triples() to World too, which will return all triples in the world.

## Type of change:
- [x] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
