### PR TITLE
Added functionality for more than one parent in new_entity

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1216,7 +1216,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
     ) -> ThingClass:
         """Create and return new entity
 
-        Makes a new entity in the ontology with given parent.
+        Makes a new entity in the ontology with given parent(s).
         Return the new entity.
 
         Throws exception if name consists of more than one word.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -16,6 +16,7 @@ import warnings
 import uuid
 import tempfile
 import types
+from typing import Union, List
 from collections import defaultdict
 
 import rdflib
@@ -1210,7 +1211,9 @@ class Ontology(  # pylint: disable=too-many-public-methods
         generations2 = self.number_of_generations(cls2, cca)
         return 2 * ccadepth / (generations1 + generations2 + 2 * ccadepth)
 
-    def new_entity(self, name: str, parent: ThingClass) -> ThingClass:
+    def new_entity(
+        self, name: str, parent: Union[ThingClass, List[ThingClass]]
+    ) -> ThingClass:
         """Create and return new entity
 
         Makes a new entity in the ontology with given parent.
@@ -1223,6 +1226,8 @@ class Ontology(  # pylint: disable=too-many-public-methods
                 f"Error in label name definition {name}: "
                 "Label consists of more than one word."
             )
-        with self:
-            entity = types.new_class(name, (parent,))
+        parent = parent if isinstance(parent, list) else [parent]
+        for thing in parent:
+            with self:
+                entity = types.new_class(name, (thing,))
         return entity

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1228,7 +1228,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
                 f"Error in label name definition '{name}': "
                 f"Label consists of more than one word."
             )
-        parents = parent if isinstance(parent, Iterable) else [parent]
+        parents = tuple(parent) if isinstance(parent, Iterable) else (parent,)
         for thing in parents:
             if not isinstance(thing, owlready2.ThingClass):
                 raise ThingClassDefinitionError(
@@ -1237,5 +1237,5 @@ class Ontology(  # pylint: disable=too-many-public-methods
                 )
 
         with self:
-            entity = types.new_class(name, tuple(parents))
+            entity = types.new_class(name, parents)
         return entity

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1236,6 +1236,6 @@ class Ontology(  # pylint: disable=too-many-public-methods
                     f"'{thing}' is not an owlready2.ThingClass."
                 )
 
-            with self:
-                entity = types.new_class(name, (thing,))
+        with self:
+            entity = types.new_class(name, tuple(parents))
         return entity

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -54,6 +54,10 @@ class LabelDefinitionError(Exception):
     """Error in label definition."""
 
 
+class ThingClassDefinitionError(Exception):
+    """Error in ThingClass definition."""
+
+
 def isinteractive():
     """Returns true if we are running from an interactive interpreater,
     false otherwise."""


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
ontology.new_entity now accepts a single parent or a list of parents.


## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
