### PR TITLE
fix #313 modification of owl temporary file in save function

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -604,11 +604,12 @@ class Ontology(  # pylint: disable=too-many-public-methods
             revmap = {value: key for key, value in FMAP.items()}
             super().save(file=filename, format=revmap[format], **kwargs)
         else:
-            with tempfile.NamedTemporaryFile(suffix=".owl") as handle:
-                super().save(file=handle.name, format="rdfxml", **kwargs)
-                graph = rdflib.Graph()
-                graph.parse(handle.name, format="xml")
-                graph.serialize(destination=filename, format=format)
+            fileTemp = os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
+            super().save(fileTemp, format="rdfxml", **kwargs)
+            graph = rdflib.Graph()
+            print(fileTemp)
+            graph.parse(fileTemp, format="xml")
+            graph.serialize(destination=filename, format=format)
 
     def get_imported_ontologies(self, recursive=False):
         """Return a list with imported ontologies.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -607,7 +607,6 @@ class Ontology(  # pylint: disable=too-many-public-methods
             fileTemp = os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
             super().save(fileTemp, format="rdfxml", **kwargs)
             graph = rdflib.Graph()
-            print(fileTemp)
             graph.parse(fileTemp, format="xml")
             graph.serialize(destination=filename, format=format)
 


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
the following code creates a problem on Windows:

```
with tempfile.NamedTemporaryFile(suffix=".owl") as handle:
   super().save(file=handle.name, format="rdfxml", **kwargs)
   graph = rdflib.Graph() 
   graph.parse(handle.name, format="xml") 
   graph.serialize(destination=filename, format=format)
```

It is related to an issue with tempfile library. The problem comes from reopening the temporary file. the first line create and open the file. so the modification simply create a file name located in the temporary folder and use that path for the successive operations.