### PR TITLE
Fix checking PR body & improve error message in CD

### DIFF
--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -33,7 +33,8 @@ jobs:
         git fetch origin
 
         LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
-        if [ "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8)" == "$(cat .github/utils/single_dependency_pr_body.txt | head -8)" ]; then
+        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
           # The dependency branch has just been merged into `${{ env.DEFAULT_REPO_BRANCH }}`
           # The dependency branch should be reset to `${{ env.DEFAULT_REPO_BRANCH }}`
           echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."
@@ -107,9 +108,16 @@ jobs:
         invoke create-docs-index
 
         if [ -n "$(git status --porcelain docs/api_reference docs/index.md)" ]; then
-          echo "The following files in the documentation have not been committed:"
+          echo -e "\u274c Discrepancies found !"
+          echo -e "The following files in the documentation must be committed:"
           git status --porcelain docs/api_reference docs/index.md
+          echo -e "\nRun:\n"
+          echo "    invoke create-api-reference-docs --pre-clean"
+          echo -e "    invoke create-docs-index\n"
+          echo "And commit the changed files."
           exit 1
+        else
+          echo -e "\u2705 All good !"
         fi
 
     - name: Deploy documentation


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
There is a minor edge-case where the CD will fail updating the `ci/dependabot-updates` branch (upon a release), this minor fix sorts out that issue.
(This edge-case was found in [Materials-Consortia/optimade-python-tools](https://github.com/Materials-Consortia/optimade-python-tools) where similar workflows are used.)

Fixes #319.

It also adds a more informative error message for what steps to do next if the CD workflow fails in a particular step.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [X] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
