### PR TITLE
Added sconverting Posix to str in get_ontology

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -84,8 +84,8 @@ class World(owlready2.World):
             of EMMO
         """
         base_iri = (
-            str(base_iri)
-            if isinstance(base_iri, pathlib.PosixPath)
+            base_iri.as_uri()
+            if isinstance(base_iri, pathlib.Path)
             else base_iri
         )
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -16,6 +16,7 @@ import warnings
 import uuid
 import tempfile
 import types
+import pathlib
 from typing import Union
 from collections import defaultdict
 from collections.abc import Iterable
@@ -82,6 +83,12 @@ class World(owlready2.World):
           - "emmo-development": load latest inferred development version
             of EMMO
         """
+        base_iri = (
+            str(base_iri)
+            if isinstance(base_iri, pathlib.PosixPath)
+            else base_iri
+        )
+
         if base_iri == "emmo":
             base_iri = (
                 "https://raw.githubusercontent.com/emmo-repo/"
@@ -1281,10 +1288,10 @@ class Ontology(  # pylint: disable=too-many-public-methods
             )
         parents = tuple(parent) if isinstance(parent, Iterable) else (parent,)
         for thing in parents:
-            if not isinstance(thing, owlready2.ThingClass):
+            if not isinstance(thing, owlready2.entity.ThingClass):
                 raise ThingClassDefinitionError(
                     f"Error in parent definition: "
-                    f"'{thing}' is not an owlready2.ThingClass."
+                    f"'{thing}' is not an owlready2.entity.ThingClass."
                 )
 
         with self:

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1288,10 +1288,10 @@ class Ontology(  # pylint: disable=too-many-public-methods
             )
         parents = tuple(parent) if isinstance(parent, Iterable) else (parent,)
         for thing in parents:
-            if not isinstance(thing, owlready2.entity.ThingClass):
+            if not isinstance(thing, owlready2.ThingClass):
                 raise ThingClassDefinitionError(
                     f"Error in parent definition: "
-                    f"'{thing}' is not an owlready2.entity.ThingClass."
+                    f"'{thing}' is not an owlready2.ThingClass."
                 )
 
         with self:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -24,7 +24,8 @@ def test_load(repo_dir: "Path") -> None:
 
     # Load a local ontology with catalog
     testonto = repo_dir / "tests" / "testonto" / "testonto.ttl"
-    onto = get_ontology(str(testonto)).load()
+    print(type(testonto))
+    onto = get_ontology(testonto).load()
     assert onto.TestClass.prefLabel.first() == "TestClass"
 
     # Use catalog file when downloading from web

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -24,7 +24,6 @@ def test_load(repo_dir: "Path") -> None:
 
     # Load a local ontology with catalog
     testonto = repo_dir / "tests" / "testonto" / "testonto.ttl"
-    print(type(testonto))
     onto = get_ontology(testonto).load()
     assert onto.TestClass.prefLabel.first() == "TestClass"
 


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
get_ontology would fail if given a valid pathlib.Posix

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
