### PR TITLE
When visualising restrictions, annotate the edges with the restriction type by default

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1180,11 +1180,14 @@ class Ontology(  # pylint: disable=too-many-public-methods
         distance between a ancestor-descendant pair (counter+1)."""
         if descendant.name == ancestor.name:
             return counter
-        return min(
-            self._number_of_generations(parent, ancestor, counter + 1)
-            for parent in descendant.get_parents()
-            if ancestor in parent.ancestors()
-        )
+        try:
+            return min(
+                self._number_of_generations(parent, ancestor, counter + 1)
+                for parent in descendant.get_parents()
+                if ancestor in parent.ancestors()
+            )
+        except ValueError:
+            return counter
 
     def closest_common_ancestors(self, cls1, cls2):
         """Returns a list with closest_common_ancestor for cls1 and cls2"""


### PR DESCRIPTION
Used to produce the graphs for the updated README for EMMO 1.0.0-beta3:
https://github.com/emmo-repo/EMMO/tree/updated-readme-and-figures

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
