### PR TITLE
Fix serialised ontology iri

### DIFF
--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -14,7 +14,7 @@ from typing import Tuple, Union
 import pyparsing
 import pandas as pd
 import ontopy
-from ontopy import World, get_ontology
+from ontopy import World
 from ontopy.utils import NoSuchLabelError
 from ontopy.manchester import evaluate
 import owlready2  # pylint: disable=C0411
@@ -64,10 +64,7 @@ def create_ontology_from_pandas(  # pylint: disable=too-many-locals,too-many-bra
     data = data.astype({"prefLabel": "str"})
 
     # Make new ontology
-    world = World()
-    onto = world.get_ontology(base_iri)
-
-    onto, catalog = get_metadata_from_dataframe(metadata, onto)
+    onto, catalog = get_metadata_from_dataframe(metadata, base_iri)
 
     # base_iri from metadata if it exists and base_iri_from_metadata
     if not base_iri_from_metadata:
@@ -155,16 +152,13 @@ def create_ontology_from_pandas(  # pylint: disable=too-many-locals,too-many-bra
 
 def get_metadata_from_dataframe(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     metadata: pd.DataFrame,
-    onto: owlready2.Ontology = None,
+    base_iri: str,
     base_iri_from_metadata: bool = True,
     catalog: dict = None,
 ) -> Tuple[ontopy.ontology.Ontology, dict]:
     """
-    Populate ontology with metada from pd.DataFrame
+    Create ontology with metadata from pd.DataFrame
     """
-
-    if onto is None:
-        onto = get_ontology()
 
     # base_iri from metadata if it exists and base_iri_from_metadata
     if base_iri_from_metadata:
@@ -175,9 +169,12 @@ def get_metadata_from_dataframe(  # pylint: disable=too-many-locals,too-many-bra
                     "More than one Ontology IRI given. The first was chosen."
                 )
             base_iri = base_iris[0] + "#"
-            onto.base_iri = base_iri
         except (TypeError, ValueError, AttributeError):
             pass
+
+    # Make new ontology
+    world = World()
+    onto = world.get_ontology(base_iri)
 
     # Get imported ontologies from metadata
     try:

--- a/ontopy/manchester.py
+++ b/ontopy/manchester.py
@@ -168,7 +168,7 @@ def evaluate(ontology: owlready2.Ontology, expr: str) -> owlready2.Construct:
             elif rtype in ("some", "only"):
                 return fneg(f(_eval(r)))
             elif rtype in ("min", "max", "exactly"):
-                cardinality = r.pop()
+                cardinality = r.pop(0)
                 return fneg(f(cardinality, _eval(r)))
             else:
                 raise ManchesterError(f"invalid restriction type: {rtype}")


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Serialised ontologies has IRI http://emmo.info/emmo/domain/onto.
Assigning onto.base_iri seems not to be sufficient to change that.
An easy solution is to create the ontology with the correct base IRI from the start.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
