### PR TITLE
Changed arguments in _has_obj_triples_spo

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -45,7 +45,7 @@ from ontopy.utils import (
     ThingClassDefinitionError,
 )
 
-# from ontopy.ontograph import OntoGraph  # FIXME: deprecate...
+from ontopy.ontograph import OntoGraph  # FIXME: deprecate...
 
 
 # Default annotations to look up
@@ -149,7 +149,7 @@ class World(owlready2.World):
 
 
 class Ontology(  # pylint: disable=too-many-public-methods
-    owlready2.Ontology,  # OntoGraph
+    owlready2.Ontology, OntoGraph
 ):
     """A generic class extending owlready2.Ontology."""
 

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -44,7 +44,8 @@ from ontopy.utils import (
     LabelDefinitionError,
     ThingClassDefinitionError,
 )
-from ontopy.ontograph import OntoGraph  # FIXME: deprecate...
+
+# from ontopy.ontograph import OntoGraph  # FIXME: deprecate...
 
 
 # Default annotations to look up
@@ -148,7 +149,7 @@ class World(owlready2.World):
 
 
 class Ontology(  # pylint: disable=too-many-public-methods
-    owlready2.Ontology, OntoGraph
+    owlready2.Ontology,  # OntoGraph
 ):
     """A generic class extending owlready2.Ontology."""
 
@@ -1135,8 +1136,16 @@ class Ontology(  # pylint: disable=too-many-public-methods
         """
         _version_iri = "http://www.w3.org/2002/07/owl#versionIRI"
         version_iri_storid = self.world._abbreviate(_version_iri)
-        if self._has_obj_triple_spo(
-            subject=self.storid, predicate=version_iri_storid
+        if self._has_obj_triple_spo(  # pylint: disable=unexpected-keyword-arg
+            # For some reason _has_obj_triples_spo exists in both
+            # owlready2.namespace.Namespace (with arguments subject/predicate)
+            # and in owlready2.triplelite._GraphManager (with arguments s/p)
+            # owlready2.Ontology inherits from Namespace directly
+            # and pylint checks that.
+            # It actually accesses the one in triplelite.
+            # subject=self.storid, predicate=version_iri_storid
+            s=self.storid,
+            p=version_iri_storid,
         ):
             self._del_obj_triple_spo(s=self.storid, p=version_iri_storid)
 


### PR DESCRIPTION
pylint complains as it checks in the definition defined in
owlready2.namespace.Namespace (which takes subject and predicate as
arguments). The function that is actually used is defined in
owlready2.triplelite.

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
