### PR TITLE
Ignore safety ID 44715 + add numpy dependency

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -71,8 +71,10 @@ jobs:
 
     # Ignore ID 44715 for now.
     # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
+    # Also ignore IDs 44716 and 44717 as they are not deemed to be as severe as it is
+    # laid out in the CVE.
     - name: Run safety
-      run: pip freeze | safety check --stdin --ignore 44715
+      run: pip freeze | safety check --stdin -i 44715 -i 44716 -i 44717
 
 
   tests:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -69,8 +69,10 @@ jobs:
     - name: Run PyLint
       run: pylint --rcfile=pyproject.toml *.py tools
 
+    # Ignore ID 44715 for now.
+    # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
     - name: Run safety
-      run: pip freeze | safety check --stdin
+      run: pip freeze | safety check --stdin --ignore 44715
 
 
   tests:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ blessings>=1.7,<2
 Cython>=0.29.21,<0.30
 defusedxml>=0.7.1,<1
 graphviz>=0.16,<0.20
+numpy>=1.19.5,<2
 openpyxl>=3.0.9,<3.1
 Owlready2>=0.28,!=0.32,!=0.34,<0.37
 packaging>=21.0<22


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #359 
Fixes #360 

Add NumPy as an explicit dependency to be able to have version control.
Set the minimum version of NumPy to the latest supported version for Python 3.6+ (v1.19).

Ignore safety ID 44715 in CI.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [X] Is the code easy to read and understand?
- [X] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [X] Does this close the issue?
- [X] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [X] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
