### PR TITLE
Workaround for failing test

### DIFF
--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -7,7 +7,7 @@ on:
 env:
   PUBLISH_UPDATE_BRANCH: master
   GIT_USER_NAME: EMMOntoPy Developers
-  GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
+  GIT_USER_EMAIL: "Team4.0@SINTEF.no"
 
 jobs:
   update-and-publish:

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       DEPENDABOT_BRANCH: ci/dependabot-updates
       GIT_USER_NAME: EMMOntoPy Developers
-      GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
+      GIT_USER_EMAIL: "Team4.0@SINTEF.no"
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -7,7 +7,7 @@ on:
 env:
   DEPENDABOT_BRANCH: ci/dependabot-updates
   GIT_USER_NAME: EMMOntoPy Developers
-  GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
+  GIT_USER_EMAIL: "Team4.0@SINTEF.no"
   DEFAULT_REPO_BRANCH: master
 
 jobs:

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DEPENDABOT_BRANCH: ci/dependabot-updates
       GIT_USER_NAME: EMMOntoPy Developers
-      GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
+      GIT_USER_EMAIL: "Team4.0@SINTEF.no"
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -241,7 +241,7 @@ jobs:
     - name: Set up git user
       run: |
         git config --global user.name "EMMOntoPy Developers"
-        git config --global user.email "Team4.0@SINTEF.onmicrosoft.com"
+        git config --global user.email "Team4.0@SINTEF.no"
 
     - name: Check API Reference and landing page
       run: |

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -12,8 +12,7 @@ def test_modules(tmpdir: "Path") -> None:
         check_module_dependencies,
     )
 
-    iri = "http://emmo.info/emmo/1.0.0-alpha2"
-    emmo = get_ontology(iri)
+    emmo = get_ontology("emmo")
     emmo.load()
 
     modules = get_module_dependencies(emmo)


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->
Fixes #384 

It seemed the issue here is that the used test ontology referenced URLs in it's corresponding catalog file that do not have a valid SSL certificate. Hence, the URL calls failed.
Since these URL calls are performed in Owlready2 it is difficult to avoid this or apply special configurations, other than downloading files directly in this package and pass a cached file to Owlready2.

I don't consider this PR a "fix", but rather a work-around.
Instead of truly fixing this issue and handle downloads within this package, the `"emmo"` shortcut is used in the test to use the latest (and valid) EMMO.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug (fix).
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
