### PR TITLE
Flb/get descendants

### DIFF
--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -9,6 +9,7 @@ The class extension is defined within.
 If desirable some of this may be moved back into owlready2.
 """
 # pylint: disable=too-many-lines,fixme,arguments-differ,protected-access
+from typing import TYPE_CHECKING, Union
 import os
 import itertools
 import inspect
@@ -17,7 +18,6 @@ import uuid
 import tempfile
 import types
 import pathlib
-from typing import Union
 from collections import defaultdict
 from collections.abc import Iterable
 
@@ -46,6 +46,9 @@ from ontopy.utils import (
 )
 
 from ontopy.ontograph import OntoGraph  # FIXME: deprecate...
+
+if TYPE_CHECKING:
+    from typing import List
 
 
 # Default annotations to look up
@@ -1270,6 +1273,81 @@ class Ontology(  # pylint: disable=too-many-public-methods
             return ancestors.difference(classes)
         return ancestors
 
+    def get_descendants(
+        self,
+        classes: "Union[List, ThingClass]",
+        common: bool = False,
+        generations: int = 1,
+        all_descendants: bool = False,
+    ):
+        """Return descendants/subclasses of all classes in `classes`.
+        Arguments:
+        - classes: to be provided as list
+        - common: only return common descendants
+        - generations: Include this number of descendant levels.
+        Returns: a list of
+        """
+        descendants = dict.fromkeys(classes, [])
+        print("----", descendants)
+
+        def _children_recursively(num, newentity, entity, descendants):
+            """Helper function to get all children up to generation."""
+            for child in self.get_children_of(newentity):
+                print("***")
+                print(entity, child)
+                print(descendants[entity])
+                print(descendants)
+                descendants[entity].append(child)
+                if num < generations:
+                    (num + 1, child, entity, descendants)
+
+        if generations == 0:
+            return set()
+
+        if not isinstance(classes, list):
+            classes = [classes]
+
+        if all_descendants is True:
+            for entity in classes:
+                descendants[
+                    entity
+                ] = entity.descendants()  # self.get_children_of(entity)
+
+        else:
+            for entity in classes:
+                _children_recursively(1, entity, entity, descendants)
+
+        # counter = 0
+        # while True:
+        #    counter+=1
+        #    if (counter > generations) & (all_descendants==False):
+        #        break
+
+        #    new_generation = dict.fromkeys(descendants.keys(), [])
+        #    for entity in classes:
+        #        print('Entity', entity)
+        #        for new_entity in current_descendants[entity]:
+        #            print('New_entity', new_entity)
+        #            print('children', self.get_children_of(new_entity))
+        # new_generation[entity].extend(self.get_children_of(new_entity))
+        #            print('****', new_generation)
+        #        print('Descendants of this entity', descendants[entity])
+        #        descendants[entity].extend(new_generation[entity])
+        #        print('New descendants', new_generation)
+        #        print('Descendats with new', descendants[entity])
+
+        #    if (all_descendants == True) & 
+        # (all(value == [] for value in new_generation.values())):
+        #        break
+        #    current_descendants = new_generation
+
+        print(descendants)
+        results = [val for _, val in descendants.items()]
+        print(results)
+        if common is True:
+            return set.intersection(*map(set, results))
+        return set(flatten(results))
+
     def get_wu_palmer_measure(self, cls1, cls2):
         """Return Wu-Palmer measure for semantic similarity.
 
@@ -1343,3 +1421,13 @@ class BlankNode:
     def __eq__(self, other):
         """For now blank nodes always compare true against each other."""
         return isinstance(other, BlankNode)
+
+
+def flatten(items):
+    """Yield items from any nested iterable."""
+    for item in items:
+        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            for sub_item in flatten(item):
+                yield sub_item
+        else:
+            yield item

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1283,7 +1283,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
         """Return descendants/subclasses of all classes in `classes`.
         Arguments:
         - classes: to be provided as list.
-        - common: only return common descendants.
+        - common: whether to only return descendants common to all classes.
         - generations: Include this number of descendant levels.
         - all_descendants: Include all descendants.
         Returns:

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1278,7 +1278,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
         classes: "Union[List, ThingClass]",
         common: bool = False,
         generations: int = None,
-    ):
+    ) -> set:
         """Return descendants/subclasses of all classes in `classes`.
         Arguments:
         - classes: to be provided as list.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1277,27 +1277,19 @@ class Ontology(  # pylint: disable=too-many-public-methods
         self,
         classes: "Union[List, ThingClass]",
         common: bool = False,
-        generations: int = -1,
-        all_descendants: bool = False,
+        generations: int = None,
     ):
         """Return descendants/subclasses of all classes in `classes`.
         Arguments:
         - classes: to be provided as list.
         - common: whether to only return descendants common to all classes.
-        - generations: Include this number of descendant levels.
-        - all_descendants: Include all descendants.
+        - generations: Include this number of descendant levels, default is all.
         Returns:
-            A list of descendants including required generation.
+            A list of descendants for given number of generations.
             If 'common'=True, the common descendants are returned
             within the specified number of generations.
-            If 'generations' is not given and 'common' is True all
-            descendants will be checked.
-            'generations' defaults to 1 if 'common' not True.
+            'generations' defaults to all.
         """
-        if (common) & (generations == -1):
-            all_descendants = True
-        elif generations == -1:
-            generations = 1
 
         if not isinstance(classes, list):
             classes = [classes]
@@ -1314,15 +1306,17 @@ class Ontology(  # pylint: disable=too-many-public-methods
         if generations == 0:
             return set()
 
-        if all_descendants is True:
+        if not generations:
             for entity in classes:
                 descendants[entity] = entity.descendants()
+                # only include proper descendants
+                descendants[entity].remove(entity)
 
         else:
             for entity in classes:
                 _children_recursively(1, entity, entity, descendants)
 
-        results = [val for _, val in descendants.items()]
+        results = descendants.values()
         if common is True:
             return set.intersection(*map(set, results))
         return set(flatten(results))

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1285,7 +1285,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
         - common: whether to only return descendants common to all classes.
         - generations: Include this number of descendant levels, default is all.
         Returns:
-            A list of descendants for given number of generations.
+            A set of descendants for given number of generations.
             If 'common'=True, the common descendants are returned
             within the specified number of generations.
             'generations' defaults to all.

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1401,10 +1401,10 @@ class Ontology(  # pylint: disable=too-many-public-methods
         generations: int = None,
     ) -> set:
         """Return descendants/subclasses of all classes in `classes`.
-        Arguments:
-        - classes: to be provided as list.
-        - common: whether to only return descendants common to all classes.
-        - generations: Include this number of descendant levels, default is all.
+        Args:
+            classes: to be provided as list.
+            common: whether to only return descendants common to all classes.
+            generations: Include this number of generations, default is all.
         Returns:
             A set of descendants for given number of generations.
             If 'common'=True, the common descendants are returned

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -1311,7 +1311,6 @@ class Ontology(  # pylint: disable=too-many-public-methods
                 descendants[entity] = entity.descendants()
                 # only include proper descendants
                 descendants[entity].remove(entity)
-
         else:
             for entity in classes:
                 _children_recursively(1, entity, entity, descendants)

--- a/ontopy/ontology.py
+++ b/ontopy/ontology.py
@@ -9,7 +9,7 @@ The class extension is defined within.
 If desirable some of this may be moved back into owlready2.
 """
 # pylint: disable=too-many-lines,fixme,arguments-differ,protected-access
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Sequence
 import os
 import itertools
 import inspect
@@ -1291,7 +1291,7 @@ class Ontology(  # pylint: disable=too-many-public-methods
             'generations' defaults to all.
         """
 
-        if not isinstance(classes, list):
+        if not isinstance(classes, Sequence):
             classes = [classes]
 
         descendants = {name: [] for name in classes}

--- a/tests/test_generation_search.py
+++ b/tests/test_generation_search.py
@@ -1,0 +1,71 @@
+from typing import TYPE_CHECKING
+import pytest
+
+if TYPE_CHECKING:
+    from ontopy.ontology import Ontology
+
+
+def test_descendants(emmo: "Ontology", repo_dir: "Path") -> None:
+    from ontopy import get_ontology
+    from ontopy.utils import LabelDefinitionError
+
+    ontopath = repo_dir / "tests" / "testonto" / "testontology.ttl"
+
+    onto = get_ontology(ontopath).load()
+
+    # Test that default gives one generation
+    assert onto.get_descendants(onto.Tree) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+    }
+    assert onto.get_descendants(onto.Tree, generations=1) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+    }
+    # Test that asking for 0 generations returns empty set
+    assert onto.get_descendants(onto.Tree, generations=0) == set()
+    # Check that more than one generation works
+    assert onto.get_descendants(onto.Tree, generations=2) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+        onto.Avocado,
+        onto.Spruce,
+    }
+    # Check that no error is generated if one of the subclasses do not have enough children for all given generations
+    assert onto.get_descendants(onto.Tree, generations=3) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+        onto.Avocado,
+        onto.Spruce,
+        onto.EngelmannSpruce,
+        onto.NorwaySpruce,
+    }
+    assert onto.get_descendants(onto.Tree, generations=4) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+        onto.Avocado,
+        onto.Spruce,
+        onto.EngelmannSpruce,
+        onto.NorwaySpruce,
+    }
+    # Check that descendants of a list is returned correctly
+    assert onto.get_descendants([onto.Tree, onto.NaturalDye]) == {
+        onto.EvergreenTree,
+        onto.DesiduousTree,
+        onto.Avocado,
+        onto.ShingledHedgehogMushroom,
+    }
+    # Check that common descendants within the number of generations are found
+    # With all descentants if number of generations not given
+    assert onto.get_descendants(
+        [onto.Tree, onto.NaturalDye], common=True, generations=2
+    ) == {onto.Avocado}
+    assert (
+        onto.get_descendants(
+            [onto.Tree, onto.NaturalDye], common=True, generations=1
+        )
+        == set()
+    )
+    assert onto.get_descendants([onto.Tree, onto.NaturalDye], common=True) == {
+        onto.Avocado
+    }

--- a/tests/test_generation_search.py
+++ b/tests/test_generation_search.py
@@ -13,25 +13,33 @@ def test_descendants(emmo: "Ontology", repo_dir: "Path") -> None:
 
     onto = get_ontology(ontopath).load()
 
-    # Test that default gives one generation
+    # Test that default gives all descendants.
     assert onto.get_descendants(onto.Tree) == {
         onto.EvergreenTree,
         onto.DesiduousTree,
+        onto.Avocado,
+        onto.Spruce,
+        onto.EngelmannSpruce,
+        onto.NorwaySpruce,
     }
+
+    # Test that asking for 0 generations returns empty set
+    assert onto.get_descendants(onto.Tree, generations=0) == set()
+
+    # Check that number of generations are returned correctly
     assert onto.get_descendants(onto.Tree, generations=1) == {
         onto.EvergreenTree,
         onto.DesiduousTree,
     }
-    # Test that asking for 0 generations returns empty set
-    assert onto.get_descendants(onto.Tree, generations=0) == set()
-    # Check that more than one generation works
+
     assert onto.get_descendants(onto.Tree, generations=2) == {
         onto.EvergreenTree,
         onto.DesiduousTree,
         onto.Avocado,
         onto.Spruce,
     }
-    # Check that no error is generated if one of the subclasses do not have enough children for all given generations
+    # Check that no error is generated if one of the subclasses do
+    # not have enough children for all given generations
     assert onto.get_descendants(onto.Tree, generations=3) == {
         onto.EvergreenTree,
         onto.DesiduousTree,
@@ -54,6 +62,9 @@ def test_descendants(emmo: "Ontology", repo_dir: "Path") -> None:
         onto.DesiduousTree,
         onto.Avocado,
         onto.ShingledHedgehogMushroom,
+        onto.Spruce,
+        onto.EngelmannSpruce,
+        onto.NorwaySpruce,
     }
     # Check that common descendants within the number of generations are found
     # With all descentants if number of generations not given

--- a/tests/testonto/testontology.ttl
+++ b/tests/testonto/testontology.ttl
@@ -1,0 +1,56 @@
+@prefix : <http://emmo.info/testontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@base <http://emmo.info/testontology> .
+
+<http://emmo.info/testontology> rdf:type owl:Ontology ;
+    owl:versionIRI <http://emmo.info/testonto/0.1.0/testontology> .
+
+
+# Annotations
+skos:prefLabel rdf:type owl:AnnotationProperty .
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+:Tree rdf:type owl:Class ;
+    rdfs:subClassOf owl:Thing ;
+    skos:prefLabel "Tree"@en .
+
+:NaturalDye rdf:type owl:Class ;
+    rdfs:subClassOf owl:Thing ;
+    skos:prefLabel "NaturalDye"@en .
+
+
+
+:EvergreenTree rdf:type owl:Class ;
+    rdfs:subClassOf :Tree ;
+    skos:prefLabel "EvergreenTree"@en .
+
+:DesiduousTree rdf:type owl:Class ;
+    rdfs:subClassOf :Tree ;
+    skos:prefLabel "DesiduousTree"@en .
+
+:Spruce rdf:type owl:Class ;
+    rdfs:subClassOf :EvergreenTree ;
+    skos:prefLabel "Spruce"@en .
+
+:Avocado rdf:type owl:Class ;
+    rdfs:subClassOf :EvergreenTree ;
+    rdfs:subClassOf :NaturalDye ;
+    skos:prefLabel "Avocado"@en .
+
+:NorwaySpruce rdf:type owl:Class ;
+    rdfs:subClassOf :Spruce ;
+    skos:prefLabel "NorwaySpruce"@en .
+
+:EngelmannSpruce rdf:type owl:Class ;
+    rdfs:subClassOf :Spruce ;
+    skos:prefLabel "EngelmannSpruce"@en .
+
+:ShingledHedgehogMushroom rdf:type owl:Class ;
+    rdfs:subClassOf :NaturalDye ;
+    skos:prefLabel "ShingledHedgehogMushroom"@en .


### PR DESCRIPTION
# Description:
Added get_descendants as function to ontology
* takes arguments
	- classes: one owl.ThingClass or an iterable sequence of such.
	- common: wether to return only common descendants or not
	- generations: number of generations to return. Defaults to all.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
