### PR TITLE
Flb/issue421

### DIFF
--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -107,7 +107,7 @@ def create_ontology_from_excel(  # pylint: disable=too-many-arguments
     except ValueError:
         pass
     else:
-        imports.extend(imports_frame["Imported ontologies"].to_list())
+        imports.extend(imports_frame["Imported ontologies"].str.strip().to_list())
 
     # Read datafile TODO: Some magic to identify the header row
     conceptdata = pd.read_excel(

--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -107,7 +107,10 @@ def create_ontology_from_excel(  # pylint: disable=too-many-arguments
     except ValueError:
         pass
     else:
-        imports.extend(imports_frame["Imported ontologies"].str.strip().to_list())
+        # Strip leading and trailing white spaces in path
+        imports.extend(
+            imports_frame["Imported ontologies"].str.strip().to_list()
+        )
 
     # Read datafile TODO: Some magic to identify the header row
     conceptdata = pd.read_excel(


### PR DESCRIPTION
# Description:
#421 
Remove leading and trailing white spaces in path to improted ontologies, 
which are easily inserted by mistake when
writing paths in excel.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
