### PR TITLE
Fixed reading web destinations defined in catalog

### DIFF
--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -261,7 +261,6 @@ def read_catalog(  # pylint: disable=too-many-locals,too-many-statements,too-man
     """
     # Protocols supported by urllib.request
     web_protocols = "http://", "https://", "ftp://"
-
     uri = str(uri)  # in case uri is a pathlib.Path object
     iris = visited_iris if visited_iris else {}
     dirs = visited_paths if visited_paths else set()
@@ -291,6 +290,7 @@ def read_catalog(  # pylint: disable=too-many-locals,too-many-statements,too-man
                 else:
                     if "Content-Length" not in msg:
                         continue
+
                     return read_catalog(
                         destfile,
                         catalog_file=catalog_file,
@@ -343,10 +343,7 @@ def read_catalog(  # pylint: disable=too-many-locals,too-many-statements,too-man
             raise ValueError(f"{gettag(uri)!r} should be 'uri'.")
         uri_as_str = uri.attrib["uri"]
         if uri_as_str.startswith(web_protocols):
-            if baseuri:
-                url = baseuri.rstrip("/#") + "/" + os.path.basename(uri_as_str)
-            else:
-                url = uri_as_str
+            url = uri_as_str
         else:
             uri_as_str = os.path.normpath(uri_as_str)
             if baseuri and baseuri.startswith(web_protocols):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -41,6 +41,14 @@ def test_load(repo_dir: "Path", testonto: "Ontology") -> None:
     ):
         get_ontology("http://emmo.info/non-existing/ontology#").load()
 
+    # test loading of ontologies that only import subparts of emmo
+    # with url to raw on github specified in catalog-file
+    onto = get_ontology(
+        "https://raw.githubusercontent.com/emmo-repo/"
+        "datamodel-ontology/master/datamodel.ttl"
+    ).load()
+    assert onto.DataModel
+
 
 def test_load_rdfs() -> None:
     from ontopy import get_ontology


### PR DESCRIPTION
Updated reading from catalog so that full urls to webprotocols when
given as destination are used directly.

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
