### PR TITLE
Fix loading in windows, url paths

### DIFF
--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -350,7 +350,7 @@ def read_catalog(  # pylint: disable=too-many-locals,too-many-statements,too-man
                 url = f"{baseuri}/{uri_as_str}"
             else:
                 url = os.path.join(baseuri if baseuri else dirname, uri_as_str)
-        url = normalise_url(url)
+        # url = normalise_url(url)
 
         iris.setdefault(uri.attrib["name"], url)
         if recursive:


### PR DESCRIPTION
This works for me now in both windows and linux.
from ontopy import get_ontology
onto = get_ontology('https://raw.githubusercontent.com/BIG-MAP/BattINFO/master/battinfo.ttl').load()**

Can you please check?

# Description:
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
