### PR TITLE
Fixed issue with exel2onto: not all relations are included in the generated ontology

### DIFF
--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -183,8 +183,8 @@ def create_ontology_from_pandas(  # pylint:disable=too-many-locals,too-many-bran
     onto.sync_python_names()
     with onto:
         remaining_rows = set(range(len(data)))
+        added_rows = set()
         while remaining_rows:
-            added_rows = set()
             for index in remaining_rows:
                 row = data.loc[index]
                 name = row["prefLabel"]
@@ -343,19 +343,19 @@ def create_ontology_from_pandas(  # pylint:disable=too-many-locals,too-many-bran
             props = properties.split(";")
             for prop in props:
                 try:
-                    concept.is_a.append(evaluate(onto, prop))
+                    concept.is_a.append(evaluate(onto, prop.strip()))
                 except pyparsing.ParseException as exc:
                     warnings.warn(
-                        f"Error in Property assignment for: {concept}. "
-                        f"Property to be Evaluated: {prop}. "
-                        f"Error is {exc}."
+                        f"Error in Property assignment for: '{concept}'. "
+                        f"Property to be Evaluated: '{prop}'. "
+                        f"{exc}"
                     )
                     concepts_with_errors["errors_in_properties"].append(name)
                 except NoSuchLabelError as exc:
                     msg = (
                         f"Error in Property assignment for: {concept}. "
                         f"Property to be Evaluated: {prop}. "
-                        f"Error is {exc}."
+                        f"{exc}"
                     )
                     if force is True:
                         warnings.warn(msg)

--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -178,13 +178,15 @@ def create_ontology_from_pandas(  # pylint:disable=too-many-locals,too-many-bran
         "missing_parents": [],
         "invalid_parents": [],
         "nonadded_concepts": [],
+        "errors_in_properties": [],
     }
 
     onto.sync_python_names()
     with onto:
         remaining_rows = set(range(len(data)))
-        added_rows = set()
+        all_added_rows = []
         while remaining_rows:
+            added_rows = set()
             for index in remaining_rows:
                 row = data.loc[index]
                 name = row["prefLabel"]
@@ -327,10 +329,11 @@ def create_ontology_from_pandas(  # pylint:disable=too-many-locals,too-many-bran
                     raise ExcelError(
                         f"Not able to add the following concepts: {unadded}."
                     )
+            all_added_rows.extend(added_rows)
 
     # Add properties in a second loop
 
-    for index in added_rows:
+    for index in all_added_rows:
         row = data.loc[index]
         properties = row["Relations"]
         if properties == "nan":

--- a/tests/testonto/excelparser/fromexcelonto.ttl
+++ b/tests/testonto/excelparser/fromexcelonto.ttl
@@ -1,84 +1,93 @@
 @prefix : <http://emmo.info/emmo/domain/onto#> .
-@prefix core: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix emmo: <http://emmo.info/emmo#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix term: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 <http://emmo.info/emmo/domain/onto> a owl:Ontology ;
-    term:contributor "SINTEF"@en,
+    dcterms:contributor "SINTEF"@en,
         "SINTEF Industry"@en ;
-    term:creator "Francesca L. Bleken"@en,
+    dcterms:creator "Francesca L. Bleken"@en,
         "Jesper Friis"@en,
         "Sylvain Gouttebroze"@en ;
-    term:title "A test domain ontology"@en ;
+    dcterms:title "A test domain ontology"@en ;
     owl:imports <https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta/emmo-inferred-chemistry> ;
     owl:versionInfo "0.01"@en .
 
 :EMMO_0264be35-e8ad-5b35-a1a3-84b37bde22d1 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Temporal pattern occurring in a time interval"@en ;
     emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Light house during one night"@en ;
-    rdfs:subClassOf :EMMO_138590b8-3333-515d-87ab-717aac8434e6,
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+            owl:someValuesFrom emmo:EMMO_d4f7d378_5e3b_468a_baa1_a7e98358cda7 ],
+        :EMMO_138590b8-3333-515d-87ab-717aac8434e6,
         :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 ;
-    core:prefLabel "FiniteTemporalPattern"@en .
+    skos:prefLabel "FiniteTemporalPattern"@en .
 
 :EMMO_1c81f1eb-8b94-5e74-96de-1aeacbdb5b93 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The boundary of a grain"@en ;
     rdfs:subClassOf :EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 ;
-    core:prefLabel "GrainBoundary"@en .
+    skos:prefLabel "GrainBoundary"@en .
 
 :EMMO_6920d08f-b1e4-5789-9778-f75f4514ef46 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
     rdfs:subClassOf owl:Thing ;
-    core:prefLabel "SpatioTemporalBoundary"@en .
+    skos:prefLabel "SpatioTemporalBoundary"@en .
 
 :EMMO_76b2eb15-3ab7-52b3-ade2-755aa390d63e a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern localized in a volume of space"@en ;
     emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Textured surface after etching"@en ;
-    rdfs:subClassOf :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8,
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+            owl:someValuesFrom :EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 ],
+        [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_e1097637_70d2_4895_973f_2396f04fa204 ;
+            owl:someValuesFrom emmo:EMMO_f1a51559_aa3d_43a0_9327_918039f0dfed ],
+        :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8,
         :EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 ;
-    core:prefLabel "FiniteSpatialPattern"@en .
+    skos:prefLabel "FiniteSpatialPattern"@en .
 
 :EMMO_b04965e6-a9bb-591f-8f8a-1adcb2c8dc39 a owl:Class ;
     rdfs:subClassOf emmo:EMMO_21f56795_ee72_4858_b571_11cfaa59c1a8 ;
-    core:prefLabel "1"@en .
+    skos:prefLabel "1"@en .
 
 :EMMO_e0b20a22-7e6f-5c81-beca-35bc5358e11b a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
     rdfs:subClassOf :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8,
         :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
-    core:prefLabel "FiniteSpatioTemporalPattern"@en .
+    skos:prefLabel "FiniteSpatioTemporalPattern"@en .
 
 :EMMO_e633d033-2af6-5f04-a706-dab826854fb1 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The boundary of a subgrain"@en ;
     rdfs:subClassOf owl:Thing ;
-    core:prefLabel "SubgrainBoundary"@en .
+    skos:prefLabel "SubgrainBoundary"@en .
 
 :EMMO_f8ad57d3-6cb5-5628-99e6-eb5915bece3a a owl:Class ;
     rdfs:subClassOf owl:Thing ;
-    core:prefLabel "SubSubgrainBoundary"@en .
+    skos:prefLabel "SubSubgrainBoundary"@en .
 
 :EMMO_138590b8-3333-515d-87ab-717aac8434e6 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern with only temporal aspect"@en ;
     emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Voltage in AC plug"@en ;
     rdfs:subClassOf owl:Thing ;
-    core:prefLabel "TemporalPattern"@en .
-
-:EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 a owl:Class ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
-    rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
-    core:prefLabel "Boundary"@en .
-
-:EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 a owl:Class ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 " "@en ;
-    rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
-    core:prefLabel "SpatialBoundary"@en .
+    skos:prefLabel "TemporalPattern"@en .
 
 :EMMO_5f50f77e-f321-53e3-af76-fe5b0a347479 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Spatial pattern without regular temporal variations"@en ;
     emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Infinite grid"@en ;
     rdfs:subClassOf :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 ;
-    core:prefLabel "SpatialPattern"@en .
+    skos:prefLabel "SpatialPattern"@en .
+
+:EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
+    rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
+    skos:prefLabel "Boundary"@en .
+
+:EMMO_472ed27e-ce08-53cb-8453-56ab363275c4 a owl:Class ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 " "@en ;
+    rdfs:subClassOf :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ;
+    skos:prefLabel "SpatialBoundary"@en .
 
 :EMMO_9fa9ca88-2891-538a-a8dd-ccb8a08b9890 a owl:Class ;
     emmo:EMMO_21ae69b4_235e_479d_8dd8_4f756f694c1b "A"@en,
@@ -86,17 +95,21 @@
         "Test"@en ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "NEED elucidation"@en ;
     rdfs:subClassOf :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
-    core:prefLabel "SpatioTemporalPattern"@en .
+    skos:prefLabel "SpatioTemporalPattern"@en .
 
 :EMMO_cd254842-c697-55f6-917d-9805c77b9187 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "everything that can be perceived or measured"@en ;
     rdfs:comment " this definition is much broader than definition of pattern such as \"the regular and repeated way in which something happens or is\""@en,
         "a pattern is defined from a contrast"@en ;
     rdfs:subClassOf emmo:EMMO_649bf97b_4397_4005_90d9_219755d92e34 ;
-    core:prefLabel "Pattern"@en .
+    skos:prefLabel "Pattern"@en .
 
 :EMMO_4b32833e-0833-56a7-903c-28a6a8191fe8 a owl:Class ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pattern occuring within a boundary in the 4D space"@en ;
     rdfs:comment "Every physical patterns are FinitePattern"@en ;
-    rdfs:subClassOf :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
-    core:prefLabel "FinitePattern"@en .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+            owl:someValuesFrom :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ],
+        :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
+    skos:prefLabel "FinitePattern"@en .
+

--- a/tests/testonto/excelparser/fromexcelonto.ttl
+++ b/tests/testonto/excelparser/fromexcelonto.ttl
@@ -112,4 +112,3 @@
             owl:someValuesFrom :EMMO_1b2bfe71-5da9-5c46-b137-be45c3e3f9c3 ],
         :EMMO_cd254842-c697-55f6-917d-9805c77b9187 ;
     skos:prefLabel "FinitePattern"@en .
-


### PR DESCRIPTION
Closes #457 

# Description:
Fixed issue #457 by avoiding resetting `added_rows` for each initial iteration.

Also made some exception messages little easier to read.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
