### PR TITLE
Bypass punning in ontodoc.

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,63 +1,63 @@
 name: CI Tests
 
 on:
-  pull_request:
+  # pull_request:
   push:
-    branches:
-      - master
-      - 'push-action/**'
+    # branches:
+    #   - master
+    #   - 'push-action/**'
 
 jobs:
-  tests:
-    name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
-    with:
-      # General
-      install_extras: "[dev,docs]"
+  # tests:
+  #   name: External
+  #   uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+  #   with:
+  #     # General
+  #     install_extras: "[dev,docs]"
 
-      # pre-commit
-      run_pre-commit: true
-      python_version_pre-commit: "3.8"
-      skip_pre-commit_hooks: pylint
+  #     # pre-commit
+  #     run_pre-commit: true
+  #     python_version_pre-commit: "3.8"
+  #     skip_pre-commit_hooks: pylint
 
-      # pylint
-      run_pylint: true
-      python_version_pylint_safety: "3.7"
-      pylint_options: "--rcfile=pyproject.toml"
-      pylint_targets: "*.py tools emmopy ontopy"
+  #     # pylint
+  #     run_pylint: true
+  #     python_version_pylint_safety: "3.7"
+  #     pylint_options: "--rcfile=pyproject.toml"
+  #     pylint_targets: "*.py tools emmopy ontopy"
 
-      # safety
-      # Ignore ID 44715 for now.
-      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-      # Also ignore IDs 44716 and 44717 as they are not deemed to be as severe as it is
-      # laid out in the CVE.
-      # Remove ignoring 48547 as soon as RDFLib/rdflib#1844 has been fixed and the fix
-      # has been released.
-      run_safety: true
-      safety_options: |
-        --ignore=44715
-        --ignore=44716
-        --ignore=44717
-        --ignore=48547
+  #     # safety
+  #     # Ignore ID 44715 for now.
+  #     # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
+  #     # Also ignore IDs 44716 and 44717 as they are not deemed to be as severe as it is
+  #     # laid out in the CVE.
+  #     # Remove ignoring 48547 as soon as RDFLib/rdflib#1844 has been fixed and the fix
+  #     # has been released.
+  #     run_safety: true
+  #     safety_options: |
+  #       --ignore=44715
+  #       --ignore=44716
+  #       --ignore=44717
+  #       --ignore=48547
 
-      # Build distribution
-      run_build_package: true
-      python_version_package: "3.7"
-      build_cmd: "python -m build"
+  #     # Build distribution
+  #     run_build_package: true
+  #     python_version_package: "3.7"
+  #     build_cmd: "python -m build"
 
-      # Build documentation
-      # Exclude base classes in emmopy.emmocheck
-      run_build_docs: true
-      python_version_docs: "3.7"
-      update_python_api_ref: true
-      update_docs_landing_page: true
-      package_dirs: |
-        emmopy
-        ontopy
-      special_file_api_ref_options: "emmopy/emmocheck.py,show_bases: false"
-      landing_page_replacements: |
-        (LICENSE.txt),(LICENSE.md)
-        (tools),(../tools)
+  #     # Build documentation
+  #     # Exclude base classes in emmopy.emmocheck
+  #     run_build_docs: true
+  #     python_version_docs: "3.7"
+  #     update_python_api_ref: true
+  #     update_docs_landing_page: true
+  #     package_dirs: |
+  #       emmopy
+  #       ontopy
+  #     special_file_api_ref_options: "emmopy/emmocheck.py,show_bases: false"
+  #     landing_page_replacements: |
+  #       (LICENSE.txt),(LICENSE.md)
+  #       (tools),(../tools)
 
 
   pytest:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8"]  #, "3.9", "3.10"]
 
     steps:
     - name: Checkout repository
@@ -111,56 +111,56 @@ jobs:
     #     cd -
 
 
-  ontodoc:
-    name: EMMO documentation (test using ontodoc)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
+  # ontodoc:
+  #   name: EMMO documentation (test using ontodoc)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.7"
+  #   - name: Set up Python 3.7
+  #     uses: actions/setup-python@v4
+  #     with:
+  #       python-version: "3.7"
 
-    - name: Check Ubuntu version we are running under
-      run: |
-        uname -a
-        sudo apt-get update
+  #   - name: Check Ubuntu version we are running under
+  #     run: |
+  #       uname -a
+  #       sudo apt-get update
 
-    - name: Current environment
-      run: env
+  #   - name: Current environment
+  #     run: env
 
-    - name: Install pandoc 2.1.2
-      run: |
-        #sudo apt-get install -y pandoc
-        wget https://github.com/jgm/pandoc/releases/download/2.1.2/pandoc-2.1.2-1-amd64.deb
-        sudo apt-get install -y ./pandoc-2.1.2-1-amd64.deb
+  #   - name: Install pandoc 2.1.2
+  #     run: |
+  #       #sudo apt-get install -y pandoc
+  #       wget https://github.com/jgm/pandoc/releases/download/2.1.2/pandoc-2.1.2-1-amd64.deb
+  #       sudo apt-get install -y ./pandoc-2.1.2-1-amd64.deb
 
-    - name: Install tzdata non-interactively
-      run: |
-        sudo ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends tzdata
-        sudo dpkg-reconfigure --frontend noninteractive tzdata
+  #   - name: Install tzdata non-interactively
+  #     run: |
+  #       sudo ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
+  #       DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends tzdata
+  #       sudo dpkg-reconfigure --frontend noninteractive tzdata
 
-    - name: Install other dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        sudo apt-get update
-        sudo apt-get install -y graphviz
-        sudo apt-get install -y texlive-xetex
-        sudo apt-get install -y texlive-latex-extra
+  #   - name: Install other dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       sudo apt-get update
+  #       sudo apt-get install -y graphviz
+  #       sudo apt-get install -y texlive-xetex
+  #       sudo apt-get install -y texlive-latex-extra
 
-    - name: Install EMMOntoPy
-      run: |
-        python setup.py install
+  #   - name: Install EMMOntoPy
+  #     run: |
+  #       python setup.py install
 
-    - name: Create EMMO documentation
-      run: |
-        cd examples/emmodoc
-        python ../../tools/ontodoc -f simple-html emmo-inferred emmo-simple.html
-        python ../../tools/ontodoc -t emmo.md -p no-self-contained emmo-inferred emmo.html
-        # pdf generation is commented out as there is a xetex error which
-        # needs to be resolved if we decide to keep ontodoc as a tool.
-        # python ../../tools/ontodoc -t emmo.md emmo-inferred emmo.pdf
-        cd -
+  #   - name: Create EMMO documentation
+  #     run: |
+  #       cd examples/emmodoc
+  #       python ../../tools/ontodoc -f simple-html emmo-inferred emmo-simple.html
+  #       python ../../tools/ontodoc -t emmo.md -p no-self-contained emmo-inferred emmo.html
+  #       # pdf generation is commented out as there is a xetex error which
+  #       # needs to be resolved if we decide to keep ontodoc as a tool.
+  #       # python ../../tools/ontodoc -t emmo.md emmo-inferred emmo.pdf
+  #       cd -

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,63 +1,63 @@
 name: CI Tests
 
 on:
-  # pull_request:
+  pull_request:
   push:
-    # branches:
-    #   - master
-    #   - 'push-action/**'
+    branches:
+      - master
+      - 'push-action/**'
 
 jobs:
-  # tests:
-  #   name: External
-  #   uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
-  #   with:
-  #     # General
-  #     install_extras: "[dev,docs]"
+  tests:
+    name: External
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+    with:
+      # General
+      install_extras: "[dev,docs]"
 
-  #     # pre-commit
-  #     run_pre-commit: true
-  #     python_version_pre-commit: "3.8"
-  #     skip_pre-commit_hooks: pylint
+      # pre-commit
+      run_pre-commit: true
+      python_version_pre-commit: "3.8"
+      skip_pre-commit_hooks: pylint
 
-  #     # pylint
-  #     run_pylint: true
-  #     python_version_pylint_safety: "3.7"
-  #     pylint_options: "--rcfile=pyproject.toml"
-  #     pylint_targets: "*.py tools emmopy ontopy"
+      # pylint
+      run_pylint: true
+      python_version_pylint_safety: "3.7"
+      pylint_options: "--rcfile=pyproject.toml"
+      pylint_targets: "*.py tools emmopy ontopy"
 
-  #     # safety
-  #     # Ignore ID 44715 for now.
-  #     # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-  #     # Also ignore IDs 44716 and 44717 as they are not deemed to be as severe as it is
-  #     # laid out in the CVE.
-  #     # Remove ignoring 48547 as soon as RDFLib/rdflib#1844 has been fixed and the fix
-  #     # has been released.
-  #     run_safety: true
-  #     safety_options: |
-  #       --ignore=44715
-  #       --ignore=44716
-  #       --ignore=44717
-  #       --ignore=48547
+      # safety
+      # Ignore ID 44715 for now.
+      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
+      # Also ignore IDs 44716 and 44717 as they are not deemed to be as severe as it is
+      # laid out in the CVE.
+      # Remove ignoring 48547 as soon as RDFLib/rdflib#1844 has been fixed and the fix
+      # has been released.
+      run_safety: true
+      safety_options: |
+        --ignore=44715
+        --ignore=44716
+        --ignore=44717
+        --ignore=48547
 
-  #     # Build distribution
-  #     run_build_package: true
-  #     python_version_package: "3.7"
-  #     build_cmd: "python -m build"
+      # Build distribution
+      run_build_package: true
+      python_version_package: "3.7"
+      build_cmd: "python -m build"
 
-  #     # Build documentation
-  #     # Exclude base classes in emmopy.emmocheck
-  #     run_build_docs: true
-  #     python_version_docs: "3.7"
-  #     update_python_api_ref: true
-  #     update_docs_landing_page: true
-  #     package_dirs: |
-  #       emmopy
-  #       ontopy
-  #     special_file_api_ref_options: "emmopy/emmocheck.py,show_bases: false"
-  #     landing_page_replacements: |
-  #       (LICENSE.txt),(LICENSE.md)
-  #       (tools),(../tools)
+      # Build documentation
+      # Exclude base classes in emmopy.emmocheck
+      run_build_docs: true
+      python_version_docs: "3.7"
+      update_python_api_ref: true
+      update_docs_landing_page: true
+      package_dirs: |
+        emmopy
+        ontopy
+      special_file_api_ref_options: "emmopy/emmocheck.py,show_bases: false"
+      landing_page_replacements: |
+        (LICENSE.txt),(LICENSE.md)
+        (tools),(../tools)
 
 
   pytest:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8"]  #, "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout repository
@@ -111,56 +111,56 @@ jobs:
     #     cd -
 
 
-  # ontodoc:
-  #   name: EMMO documentation (test using ontodoc)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
+  ontodoc:
+    name: EMMO documentation (test using ontodoc)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Set up Python 3.7
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: "3.7"
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.7"
 
-  #   - name: Check Ubuntu version we are running under
-  #     run: |
-  #       uname -a
-  #       sudo apt-get update
+    - name: Check Ubuntu version we are running under
+      run: |
+        uname -a
+        sudo apt-get update
 
-  #   - name: Current environment
-  #     run: env
+    - name: Current environment
+      run: env
 
-  #   - name: Install pandoc 2.1.2
-  #     run: |
-  #       #sudo apt-get install -y pandoc
-  #       wget https://github.com/jgm/pandoc/releases/download/2.1.2/pandoc-2.1.2-1-amd64.deb
-  #       sudo apt-get install -y ./pandoc-2.1.2-1-amd64.deb
+    - name: Install pandoc 2.1.2
+      run: |
+        #sudo apt-get install -y pandoc
+        wget https://github.com/jgm/pandoc/releases/download/2.1.2/pandoc-2.1.2-1-amd64.deb
+        sudo apt-get install -y ./pandoc-2.1.2-1-amd64.deb
 
-  #   - name: Install tzdata non-interactively
-  #     run: |
-  #       sudo ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
-  #       DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends tzdata
-  #       sudo dpkg-reconfigure --frontend noninteractive tzdata
+    - name: Install tzdata non-interactively
+      run: |
+        sudo ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends tzdata
+        sudo dpkg-reconfigure --frontend noninteractive tzdata
 
-  #   - name: Install other dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       sudo apt-get update
-  #       sudo apt-get install -y graphviz
-  #       sudo apt-get install -y texlive-xetex
-  #       sudo apt-get install -y texlive-latex-extra
+    - name: Install other dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        sudo apt-get update
+        sudo apt-get install -y graphviz
+        sudo apt-get install -y texlive-xetex
+        sudo apt-get install -y texlive-latex-extra
 
-  #   - name: Install EMMOntoPy
-  #     run: |
-  #       python setup.py install
+    - name: Install EMMOntoPy
+      run: |
+        python setup.py install
 
-  #   - name: Create EMMO documentation
-  #     run: |
-  #       cd examples/emmodoc
-  #       python ../../tools/ontodoc -f simple-html emmo-inferred emmo-simple.html
-  #       python ../../tools/ontodoc -t emmo.md -p no-self-contained emmo-inferred emmo.html
-  #       # pdf generation is commented out as there is a xetex error which
-  #       # needs to be resolved if we decide to keep ontodoc as a tool.
-  #       # python ../../tools/ontodoc -t emmo.md emmo-inferred emmo.pdf
-  #       cd -
+    - name: Create EMMO documentation
+      run: |
+        cd examples/emmodoc
+        python ../../tools/ontodoc -f simple-html emmo-inferred emmo-simple.html
+        python ../../tools/ontodoc -t emmo.md -p no-self-contained emmo-inferred emmo.html
+        # pdf generation is commented out as there is a xetex error which
+        # needs to be resolved if we decide to keep ontodoc as a tool.
+        # python ../../tools/ontodoc -t emmo.md emmo-inferred emmo.pdf
+        cd -

--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -393,28 +393,28 @@ class OntoDoc:
         if hasattr(item, "instances"):
             points = []
             for instance in item.instances():
-                try:
-                    if item in instance.is_instance_of:
-                        points.append(
-                            point_style.format(
-                                point=asstring(instance, link_style),
-                                ontology=onto,
-                            )
-                        )
-                    if points:
-                        value = points_style.format(
-                            points="".join(points), ontology=onto
-                        )
-                        doc.append(
-                            annotation_style.format(
-                                key="Individuals", value=value, ontology=onto
-                            )
-                        )
-                except TypeError:
+                if isinstance(instance.is_instance_of, property):
                     warnings.warn(
                         f'Ignoring instance "{instance}" which is both and '
                         "indivudual and class. Ontodoc does not support "
                         "punning at the present moment."
+                    )
+                    continue
+                if item in instance.is_instance_of:
+                    points.append(
+                        point_style.format(
+                            point=asstring(instance, link_style),
+                            ontology=onto,
+                        )
+                    )
+                if points:
+                    value = points_style.format(
+                        points="".join(points), ontology=onto
+                    )
+                    doc.append(
+                        annotation_style.format(
+                            key="Individuals", value=value, ontology=onto
+                        )
                     )
 
         return "\n".join(doc)

--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -407,7 +407,6 @@ class OntoDoc:
                             point=asstring(instance, link_style),
                             ontology=onto,
                         )
-
                     )
                 if points:
                     value = points_style.format(

--- a/ontopy/ontodoc.py
+++ b/ontopy/ontodoc.py
@@ -392,37 +392,31 @@ class OntoDoc:
         # Instances (individuals)
         if hasattr(item, "instances"):
             points = []
-            for individual in item.instances():
-                print("item", item, "is a", item.is_a)
-                print(
-                    "individual",
-                    individual,
-                    "is instance of",
-                    individual.is_instance_of,
-                )
-
-                # print(item.individual.is_instance_of)
-
-            for entity in [
-                _ for _ in item.instances() if item in _.is_instance_of
-            ]:
-                print("entity", entity)
-                print("a", points)
-                points.append(
-                    point_style.format(
-                        point=asstring(entity, link_style), ontology=onto
+            for instance in item.instances():
+                try:
+                    if item in instance.is_instance_of:
+                        points.append(
+                            point_style.format(
+                                point=asstring(instance, link_style),
+                                ontology=onto,
+                            )
+                        )
+                    if points:
+                        value = points_style.format(
+                            points="".join(points), ontology=onto
+                        )
+                        doc.append(
+                            annotation_style.format(
+                                key="Individuals", value=value, ontology=onto
+                            )
+                        )
+                except TypeError:
+                    warnings.warn(
+                        f'Ignoring instance "{instance}" which is both and '
+                        "indivudual and class. Ontodoc does not support "
+                        "punning at the present moment."
                     )
-                )
-                print("b", points)
-            if points:
-                value = points_style.format(
-                    points="".join(points), ontology=onto
-                )
-                doc.append(
-                    annotation_style.format(
-                        key="Individuals", value=value, ontology=onto
-                    )
-                )
+
         return "\n".join(doc)
 
     def itemsdoc(self, items, header_level=3):

--- a/ontopy/utils.py
+++ b/ontopy/utils.py
@@ -57,6 +57,10 @@ class UnknownVersion(EMMOntoPyException):
     """Cannot retrieve version from a package."""
 
 
+class IndividualWarning(EMMOntoPyWarning):
+    """A warning related to an individual, e.g. punning."""
+
+
 class NoSuchLabelError(LookupError, AttributeError, EMMOntoPyException):
     """Error raised when a label cannot be found."""
 

--- a/tests/testonto/testonto_w_individual.ttl
+++ b/tests/testonto/testonto_w_individual.ttl
@@ -1,0 +1,23 @@
+@prefix : <http://emmo.info/testonto#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@base <http://emmo.info/testonto> .
+
+<http://emmo.info/testonto> rdf:type owl:Ontology ;
+                             owl:versionIRI <http://emmo.info/testonto/0.1.0> ;
+			     owl:versionInfo "0.1.0" .
+
+skos:prefLabel rdf:type owl:AnnotationProperty .
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+:testclass rdf:type owl:Class ;
+    rdfs:subClassOf owl:Thing ;
+    skos:prefLabel "TestClass"@en .
+
+
+:testindividual rdf:type owl:NamedIndividual ,
+                           :testclass .

--- a/tests/testonto/testonto_w_individual.ttl
+++ b/tests/testonto/testonto_w_individual.ttl
@@ -20,4 +20,5 @@ skos:altLabel rdf:type owl:AnnotationProperty .
 
 
 :testindividual rdf:type owl:NamedIndividual ,
-                           :testclass .
+                           :testclass ;
+		skos:prefLabel "testindividual"@en .

--- a/tests/testonto/testonto_w_punning.ttl
+++ b/tests/testonto/testonto_w_punning.ttl
@@ -1,0 +1,23 @@
+@prefix : <http://emmo.info/testonto#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@base <http://emmo.info/testonto> .
+
+<http://emmo.info/testonto> rdf:type owl:Ontology ;
+                             owl:versionIRI <http://emmo.info/testonto/0.1.0> ;
+			     owl:versionInfo "0.1.0" .
+
+skos:prefLabel rdf:type owl:AnnotationProperty .
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+:testclass rdf:type owl:Class ;
+    rdfs:subClassOf owl:Thing ;
+    skos:prefLabel "TestClass"@en .
+
+
+:testclass rdf:type owl:NamedIndividual ,
+                           :testclass .

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -24,7 +24,9 @@ def tool(request: "Dict[str, Any]") -> "ModuleType":
     if str(original_tool_path.parent) not in sys.path:
         sys.path.append(str(original_tool_path.parent))
 
-    content_parent = "\n".join(os.walk(original_tool_path.parent))
+    content_parent = "\n".join(
+        str(_) for _ in os.walk(original_tool_path.parent)
+    )
     assert (
         original_tool_path.exists()
     ), f"The requested tool ({request.param}) was not found in {original_tool_path.parent}.\nContents:\n{content_parent}"

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -13,6 +13,7 @@ def tool(request: "Dict[str, Any]") -> "ModuleType":
     """Import a tool as a module."""
     from copy import deepcopy
     import importlib
+    import os
     from pathlib import Path
     import sys
 
@@ -23,9 +24,10 @@ def tool(request: "Dict[str, Any]") -> "ModuleType":
     if str(original_tool_path.parent) not in sys.path:
         sys.path.append(str(original_tool_path.parent))
 
+    content_parent = "\n".join(os.walk(original_tool_path.parent))
     assert (
         original_tool_path.exists()
-    ), f"The requested tool ({request.param}) was not found in {original_tool_path.parent}"
+    ), f"The requested tool ({request.param}) was not found in {original_tool_path.parent}.\nContents:\n{content_parent}"
     tool_path = None
     try:
         tool_path = original_tool_path.rename(

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -5,38 +5,100 @@ import pytest
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import Any, Dict
+    from typing import Any, Callable, Dict
 
 
-@pytest.fixture
-def tool(request: "Dict[str, Any]") -> "ModuleType":
-    """Import a tool as a module."""
+@pytest.fixture(scope="module", autouse=True)
+def rename_tools() -> None:
+    """Add a `.py` extension to all tools.
+
+    Run prior to all tests in this module.
+    """
     from copy import deepcopy
-    import importlib
     import os
     from pathlib import Path
+    import shutil
     import sys
 
     original_sys_path = deepcopy(sys.path)
-    original_tool_path: Path = (
-        Path(__file__).resolve().parent.parent.parent / "tools" / request.param
-    )
-    if str(original_tool_path.parent) not in sys.path:
-        sys.path.append(str(original_tool_path.parent))
+    tools_path: Path = Path(__file__).resolve().parent.parent.parent / "tools"
 
-    content_parent = "\n".join(
-        str(_) for _ in os.walk(original_tool_path.parent)
-    )
-    assert (
-        original_tool_path.exists()
-    ), f"The requested tool ({request.param}) was not found in {original_tool_path.parent}.\nContents:\n{content_parent}"
-    tool_path = None
-    try:
-        tool_path = original_tool_path.rename(
-            original_tool_path.with_suffix(".py")
-        )
-        yield importlib.import_module(request.param)
-    finally:
-        if tool_path and tool_path.exists():
-            tool_path.rename(tool_path.with_suffix(""))
-        sys.path = original_sys_path
+    if str(tools_path) not in sys.path:
+        sys.path.append(str(tools_path))
+
+    # Add ".py" suffix to all tools
+    for (
+        dirpath,
+        dirnames,
+        filenames,
+    ) in os.walk(tools_path):
+        if dirpath != str(tools_path):
+            continue
+
+        if dirnames:
+            for dirname in dirnames:
+                if dirname == "__pycache__":
+                    shutil.rmtree(
+                        Path(dirpath) / "__pycache__", ignore_errors=True
+                    )
+
+        for filename in filenames:
+            filepath = Path(dirpath) / filename
+            assert (
+                filepath.suffix == ""
+            ), f"A suffix was found (not expected) for file: {filepath}"
+
+            filepath.rename(filepath.with_suffix(".py"))
+
+    yield
+
+    # Remove ".py" suffix from all tools
+    for (
+        dirpath,
+        dirnames,
+        filenames,
+    ) in os.walk(tools_path):
+        if dirpath != str(tools_path):
+            continue
+
+        if dirnames:
+            for dirname in dirnames:
+                if dirname == "__pycache__":
+                    shutil.rmtree(
+                        Path(dirpath) / "__pycache__", ignore_errors=True
+                    )
+
+        for filename in filenames:
+            filepath = Path(dirpath) / filename
+            assert (
+                filepath.suffix == ".py"
+            ), f"A suffix was NOT found (not expected) for file: {filepath}"
+
+            filepath.rename(filepath.with_suffix(""))
+
+    sys.path = original_sys_path
+
+
+@pytest.fixture
+def get_tool() -> "Callable[[str], ModuleType]":
+    """Import a tool as a module."""
+    import importlib
+    from pathlib import Path
+    import sys
+
+    def _get_tool(name: str) -> "ModuleType":
+        """Import and return named tool."""
+        tool_path: Path = (
+            Path(__file__).resolve().parent.parent.parent / "tools" / name
+        ).with_suffix(".py")
+        assert (
+            str(tool_path.parent) in sys.path
+        ), f"'tools' dir not found in sys.path. Did `rename_tools` fixture run?\nsys.path: {sys.path}"
+
+        assert (
+            tool_path.exists()
+        ), f"The requested tool ({name}) was not found in {tool_path.parent}."
+
+        return importlib.import_module(name)
+
+    return _get_tool

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -26,12 +26,13 @@ def tool(request: "Dict[str, Any]") -> "ModuleType":
     assert (
         original_tool_path.exists()
     ), f"The requested tool ({request.param}) was not found in {original_tool_path.parent}"
+    tool_path = None
     try:
         tool_path = original_tool_path.rename(
-            original_tool_path.with_name(f"{request.param}.py")
+            original_tool_path.with_suffix(".py")
         )
         yield importlib.import_module(request.param)
     finally:
         if tool_path and tool_path.exists():
-            tool_path.rename(tool_path.with_name(request.param))
+            tool_path.rename(tool_path.with_suffix(""))
         sys.path = original_sys_path

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import Any, Callable, Dict
+    from typing import Callable
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -13,6 +13,13 @@ def rename_tools() -> None:
     """Add a `.py` extension to all tools.
 
     Run prior to all tests in this module.
+    First, rename all tools (adding a `.py` suffix) to make them importable as a
+    module. Then stop executing this fixture for a while (yield) and run all the tests
+    in the module. Then after they're done, rename the tools back (remove the `.py`
+    suffix) and also return `sys.path` to its original state prior to running the
+    tests.
+    To make the importability work, the `tools` folder had to be added to the
+    `sys.path`.
     """
     from copy import deepcopy
     import os
@@ -81,7 +88,10 @@ def rename_tools() -> None:
 
 @pytest.fixture
 def get_tool() -> "Callable[[str], ModuleType]":
-    """Import a tool as a module."""
+    """Import a tool as a module.
+
+    Requires the fixture `rename_tools` to have been run already.
+    """
     import importlib
     from pathlib import Path
     import sys

--- a/tests/tools/test_emmocheck.py
+++ b/tests/tools/test_emmocheck.py
@@ -1,14 +1,24 @@
 """Test the `emmocheck` tool."""
-import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Callable
 
 
-@pytest.mark.parametrize("tool", ["emmocheck"], indirect=True)
-def test_run(tool) -> None:
-    """Check that running `emmocheck` works."""
+def test_run(get_tool: "Callable[[str], ModuleType]") -> None:
+    """Check that running `emmocheck` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+
+    """
     from pathlib import Path
 
     test_file = (
         Path(__file__).resolve().parent.parent / "testonto" / "models.ttl"
     )
+    emmocheck = get_tool("emmocheck")
 
-    tool.main([str(test_file)])
+    emmocheck.main([str(test_file)])

--- a/tests/tools/test_excel2onto.py
+++ b/tests/tools/test_excel2onto.py
@@ -1,12 +1,24 @@
 """Test the `ontograph` tool."""
-from pathlib import Path
-import os
-import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+    from typing import Callable
 
 
-@pytest.mark.parametrize("tool", ["excel2onto"], indirect=True)
-def test_run(tool, tmpdir: Path) -> None:
-    """Check that running `excel2onto` works."""
+def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
+    """Check that running `excel2onto` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent
         / "test_excelparser"
@@ -17,10 +29,13 @@ def test_run(tool, tmpdir: Path) -> None:
         / "test_excelparser"
         / "onto_update.xlsx"
     )
+    excel2onto = get_tool("excel2onto")
 
-    tool.main([f"--output={str(tmpdir)}/onto.ttl", "--force", str(test_file)])
+    excel2onto.main(
+        [f"--output={str(tmpdir)}/onto.ttl", "--force", str(test_file)]
+    )
 
-    tool.main(
+    excel2onto.main(
         [
             f"--output={str(tmpdir)}/onto.ttl",
             "--force",
@@ -29,7 +44,7 @@ def test_run(tool, tmpdir: Path) -> None:
         ]
     )
 
-    tool.main(
+    excel2onto.main(
         [
             f"--output={str(tmpdir)}/ontology.ttl",
             "--force",

--- a/tests/tools/test_ontoconvert.py
+++ b/tests/tools/test_ontoconvert.py
@@ -1,14 +1,27 @@
 """Test the `ontoconvert` tool."""
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+    from typing import Callable
 
 
-@pytest.mark.parametrize("tool", ["ontoconvert"], indirect=True)
-def test_run(tool, tmpdir: Path) -> None:
-    """Check that running `ontoconvert` works."""
+def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
+    """Check that running `ontoconvert` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent / "testonto" / "models.ttl"
     )
+    ontoconvert = get_tool("ontoconvert")
 
-    tool.main([str(test_file), str(tmpdir / "test.ttl")])
+    ontoconvert.main([str(test_file), str(tmpdir / "test.ttl")])

--- a/tests/tools/test_ontodoc.py
+++ b/tests/tools/test_ontodoc.py
@@ -10,7 +10,15 @@ if TYPE_CHECKING:
 
 
 def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
-    """Check that running `ontodoc` works."""
+    """Check that running `ontodoc` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
     from pathlib import Path
 
     test_file = (
@@ -27,7 +35,15 @@ def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
 def test_run_w_individual(
     get_tool: "Callable[[str], ModuleType]", tmpdir: "Path"
 ) -> None:
-    """Check that running `ontodoc` works when there is an individual."""
+    """Check that running `ontodoc` works when there is an individual.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
     from pathlib import Path
 
     test_file = (
@@ -51,6 +67,13 @@ def test_run_w_punning(
 ) -> None:
     """Check that running `ontodoc` works even if there is a punned individual.
     This will throw and extra warning as the punned individual will be ignored.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
     """
     from pathlib import Path
 

--- a/tests/tools/test_ontodoc.py
+++ b/tests/tools/test_ontodoc.py
@@ -15,3 +15,38 @@ def test_run(tool, tmpdir: Path) -> None:
     tool.main(
         [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
     )
+
+
+@pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
+def test_run_w_individual(tool, tmpdir: Path) -> None:
+    """Check that running `ontodoc` works when there is an individual."""
+    test_file = (
+        Path(__file__).resolve().parent.parent
+        / "testonto"
+        / "testonto_w_individual.ttl"
+    )
+
+    tool.main([str(test_file), str(tmpdir / "test.md")])
+    tool.main(
+        [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
+    )
+
+
+@pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
+@pytest.mark.filterwarnings(
+    "ignore:Ignoring instance"
+)  # currently pytest is set to accept warnings, but this might change in the future
+def test_run(tool, tmpdir: Path) -> None:
+    """Check that running `ontodoc` works even if there is a punned individual.
+    This will throw and extra warning as the punned individual will be ignored.
+    """
+    test_file = (
+        Path(__file__).resolve().parent.parent
+        / "testonto"
+        / "testonto_w_punning.ttl"
+    )
+
+    tool.main([str(test_file), str(tmpdir / "test.md")])
+    tool.main(
+        [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
+    )

--- a/tests/tools/test_ontodoc.py
+++ b/tests/tools/test_ontodoc.py
@@ -36,7 +36,7 @@ def test_run_w_individual(tool, tmpdir: Path) -> None:
 @pytest.mark.filterwarnings(
     "ignore:Ignoring instance"
 )  # currently pytest is set to accept warnings, but this might change in the future
-def test_run(tool, tmpdir: Path) -> None:
+def test_run_w_punning(tool, tmpdir: Path) -> None:
     """Check that running `ontodoc` works even if there is a punned individual.
     This will throw and extra warning as the punned individual will be ignored.
     """

--- a/tests/tools/test_ontodoc.py
+++ b/tests/tools/test_ontodoc.py
@@ -1,52 +1,67 @@
 """Test the `ontodoc` tool."""
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+    from typing import Callable
 
-@pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
-def test_run(tool, tmpdir: Path) -> None:
+
+def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
     """Check that running `ontodoc` works."""
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent / "testonto" / "models.ttl"
     )
+    ontodoc = get_tool("ontodoc")
 
-    tool.main([str(test_file), str(tmpdir / "test.md")])
-    tool.main(
+    ontodoc.main([str(test_file), str(tmpdir / "test.md")])
+    ontodoc.main(
         [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
     )
 
 
-@pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
-def test_run_w_individual(tool, tmpdir: Path) -> None:
+def test_run_w_individual(
+    get_tool: "Callable[[str], ModuleType]", tmpdir: "Path"
+) -> None:
     """Check that running `ontodoc` works when there is an individual."""
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent
         / "testonto"
         / "testonto_w_individual.ttl"
     )
+    ontodoc = get_tool("ontodoc")
 
-    tool.main([str(test_file), str(tmpdir / "test.md")])
-    tool.main(
+    ontodoc.main([str(test_file), str(tmpdir / "test.md")])
+    ontodoc.main(
         [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
     )
 
 
-@pytest.mark.parametrize("tool", ["ontodoc"], indirect=True)
 @pytest.mark.filterwarnings(
     "ignore:Ignoring instance"
 )  # currently pytest is set to accept warnings, but this might change in the future
-def test_run_w_punning(tool, tmpdir: Path) -> None:
+def test_run_w_punning(
+    get_tool: "Callable[[str], ModuleType]", tmpdir: "Path"
+) -> None:
     """Check that running `ontodoc` works even if there is a punned individual.
     This will throw and extra warning as the punned individual will be ignored.
     """
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent
         / "testonto"
         / "testonto_w_punning.ttl"
     )
+    ontodoc = get_tool("ontodoc")
 
-    tool.main([str(test_file), str(tmpdir / "test.md")])
-    tool.main(
+    ontodoc.main([str(test_file), str(tmpdir / "test.md")])
+    ontodoc.main(
         [str(test_file), "--format=simple-html", str(tmpdir / "test.html")]
     )

--- a/tests/tools/test_ontograph.py
+++ b/tests/tools/test_ontograph.py
@@ -1,14 +1,27 @@
 """Test the `ontograph` tool."""
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+    from typing import Callable
 
 
-@pytest.mark.parametrize("tool", ["ontograph"], indirect=True)
-def test_run(tool, tmpdir: Path) -> None:
-    """Check that running `ontograph` works."""
+def test_run(get_tool: "Callable[[str], ModuleType]", tmpdir: "Path") -> None:
+    """Check that running `ontograph` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
+    from pathlib import Path
+
     test_file = (
         Path(__file__).resolve().parent.parent / "testonto" / "models.ttl"
     )
+    ontograph = get_tool("ontograph")
 
-    tool.main([str(test_file), str(tmpdir / "test.png")])
+    ontograph.main([str(test_file), str(tmpdir / "test.png")])

--- a/tests/tools/test_ontoversion.py
+++ b/tests/tools/test_ontoversion.py
@@ -1,14 +1,26 @@
 """Test the `ontoversion` tool."""
-import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Callable
 
 
-@pytest.mark.parametrize("tool", ["ontoversion"], indirect=True)
-def test_run(tool) -> None:
-    """Check running `ontoversion` works."""
+def test_run(get_tool: "Callable[[str], ModuleType]") -> None:
+    """Check running `ontoversion` works.
+
+    Parameters:
+        get_tool: Local module fixture to load a named tool as a module.
+            See the current folder's `conftest.py` file.
+        tmpdir: A generic pytest fixture to generate a temporary directory, which will
+            exist only for the lifetime of this test function.
+
+    """
     from pathlib import Path
 
     test_file = (
         Path(__file__).resolve().parent.parent / "testonto" / "testonto.ttl"
     )
+    ontoversion = get_tool("ontoversion")
 
-    tool.main([str(test_file), "--format", "ttl"])
+    ontoversion.main([str(test_file), "--format", "ttl"])


### PR DESCRIPTION
# Description:
Closes #506.
Ontodoc fails when punned individuals are included in the ontology. 
After discussions with various people (see #507)  we have agreed to not support punning for now.
This might be changed in the future if we see the need.

Tests have been added to see that ontodoc runs for ontologies with an individual, and that it runs with a warning
when the individual is a punned individual. Pytest is set to ignore that particualr warning so that this test 
will continue to pass if pytest is set to fail on warnings as well in the future.
 
## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist:
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments:
<!-- Additional comments here, including clarifications on checklist if applicable. -->
