### PR TITLE
Excel2onto improve errormsg

### DIFF
--- a/ontopy/excelparser.py
+++ b/ontopy/excelparser.py
@@ -848,7 +848,6 @@ def _add_entities(
                 ):
                     for annotation in row["Other annotations"].split(";"):
                         key, value = annotation.split("=", 1)
-                        print("key" + key, value + "value")
                         try:
                             entity[key.strip(" ")] = english(value.strip(" "))
                         except NoSuchLabelError as exc:


### PR DESCRIPTION
# Description
The  excel2onto feature failed with bad error messages for:

-  Leading or trailing white spaces in iris of imported ontologies. These are now removed.
-  the code failed with bad warnings if extra non-existing annotations were added. Improved error message and skip the annotation if option --force is chosen.



## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
