### PR TITLE
Added range and domain to properties in reference documentation

### DIFF
--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -308,6 +308,12 @@ class ModuleDocumentation:
                 f"{display_text}</a>"
             )
 
+        def _display_iri_label(iri: str) -> str:
+            """Return a compact display label for well-known IRIs."""
+            if iri.startswith("http://www.w3.org/2001/XMLSchema#"):
+                return f"xsd:{iri.split('#', maxsplit=1)[-1]}"
+            return iri
+
         def _linkify_value(val: str) -> str:
             """
             If `val` contains one or more IRIs, return them as separate links.
@@ -332,10 +338,10 @@ class ModuleDocumentation:
                     f'style="max-width:400px; max-height:300px;"/></a>'
                 )
 
-            # otherwise, link each separately, showing full IRI as label
+            # otherwise, link each separately with a compact display label
             links = []
             for u in urls:
-                links.append(_html_links(u, u))  # use full IRI as label
+                links.append(_html_links(u, _display_iri_label(u)))
             return "; ".join(links)
 
         def add_keyvalue(
@@ -376,8 +382,6 @@ class ModuleDocumentation:
                         + "</li>"
                     )
                 # if value is a class 'type'
-                elif isinstance(val, type):
-                    strval += _linkify_value(get_label(val))
                 else:
                     strval += _linkify_value(val)
                     strval = strval.replace("\n", "<br>")
@@ -551,13 +555,30 @@ class ModuleDocumentation:
                             except (NoSuchLabelError, AttributeError):
                                 pass
                             try:
-                                # Remove None from range list if present (Owlready2 quirk)
-                                entity.range = [
+                                # Remove None from range lists if present
+                                # (Owlready2 quirk). Use the range IRI only for
+                                # Python datatypes, otherwise keep the ontology
+                                # entity so it is rendered as an internal link.
+                                ranges = [
                                     r for r in entity.range if r is not None
                                 ]
+                                range_iris = [
+                                    r for r in entity.range_iri if r is not None
+                                ]
 
-                                if entity.range:
-                                    add_keyvalue("Range", entity.range)
+                                range_values = [
+                                    (
+                                        range_
+                                        if hasattr(range_, "iri")
+                                        else range_iri
+                                    )
+                                    for range_, range_iri in zip(
+                                        ranges, range_iris
+                                    )
+                                ]
+
+                                if range_values:
+                                    add_keyvalue("Range", range_values)
                             except (NoSuchLabelError, AttributeError):
                                 pass
 

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -166,9 +166,9 @@ class ModuleDocumentation:
         elif isinstance(entity, owlready2.ObjectPropertyClass):
             self.object_properties.add(entity)
         elif isinstance(entity, owlready2.DataPropertyClass):
-            self.object_properties.add(entity)
+            self.data_properties.add(entity)
         elif isinstance(entity, owlready2.AnnotationPropertyClass):
-            self.object_properties.add(entity)
+            self.annotation_properties.add(entity)
         elif isinstance(entity, owlready2.Thing):
             if (
                 hasattr(entity.__class__, "iri")

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -19,6 +19,7 @@ from rdflib import DCTERMS, OWL, URIRef
 
 from ontopy.ontology import Ontology, get_ontology
 from ontopy.utils import asstring, get_label
+from ontopy.exceptions import NoSuchLabelError
 
 import owlready2  # pylint: disable=wrong-import-order
 
@@ -521,7 +522,7 @@ class ModuleDocumentation:
                                     ontology=self.ontology,
                                 ),
                             )
-                        # Add SubclassOf
+                        # Add SubclassOf/SubPropertyOf/InstanceOf for direct parents
                         if isinstance(entity, owlready2.ThingClass):
                             add_keyvalue("Subclass Of", parents)
                         elif isinstance(entity, (owlready2.PropertyClass)):
@@ -535,6 +536,27 @@ class ModuleDocumentation:
                         # Add Restrictions if any
                         if restrictions:
                             add_keyvalue("Restrictions", restrictions)
+                        if isinstance(entity, owlready2.PropertyClass):
+                            # Add domain and range for properties
+                            try:
+                                # Remove None from domain list if present (Owlready2 quirk)
+                                entity.domain = [
+                                    d for d in entity.domain if d is not None
+                                ]
+                                if entity.domain:
+                                    add_keyvalue("Domain", entity.domain)
+                            except (NoSuchLabelError, AttributeError):
+                                pass
+                            try:
+                                # Remove None from range list if present (Owlready2 quirk)
+                                entity.range = [
+                                    r for r in entity.range if r is not None
+                                ]
+
+                                if entity.range:
+                                    add_keyvalue("Range", entity.range)
+                            except (NoSuchLabelError, AttributeError):
+                                pass
 
                     lines.extend(["  </table>", ""])
 

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -375,6 +375,9 @@ class ModuleDocumentation:
                         )
                         + "</li>"
                     )
+                # if value is a class 'type'
+                elif isinstance(val, type):
+                    strval += _html_links(val.iri, get_label(val))
                 else:
                     strval += _linkify_value(val)
                     strval = strval.replace("\n", "<br>")

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -377,7 +377,7 @@ class ModuleDocumentation:
                     )
                 # if value is a class 'type'
                 elif isinstance(val, type):
-                    strval += _html_links(val.iri, get_label(val))
+                    strval += _linkify_value(get_label(val))
                 else:
                     strval += _linkify_value(val)
                     strval = strval.replace("\n", "<br>")

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -522,7 +522,12 @@ class ModuleDocumentation:
                                 ),
                             )
                         # Add SubclassOf
-                        add_keyvalue("Subclass Of", parents)
+                        if isinstance(entity, owlready2.ThingClass):
+                            add_keyvalue("Subclass Of", parents)
+                        elif isinstance(entity, (owlready2.PropertyClass)):
+                            add_keyvalue("Subproperty Of", parents)
+                        elif isinstance(entity, owlready2.Thing):
+                            add_keyvalue("Instance of", parents)
                         # Add Subclasses if any
                         if subclasses:
                             add_keyvalue("Subclasses", subclasses)


### PR DESCRIPTION
Look here to check how it looks: https://emmo-repo.github.io/domain-atomistic/atomistic.html#object-properties

Due to some strange issues with Owlready2 returning various types of empty lists I ahd to add do some cleaning of the ranges and domains before adding them.