### PR TITLE
Separate Reference index class from Ontology Documentation class

### DIFF
--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -199,9 +199,13 @@ class ModuleDocumentation:
 
         return title
 
-    def get_header(self) -> str:
-        """Return a the reStructuredText header as a string."""
-        heading = f"Module: {self.get_title()}"
+    def get_header(self, include_module_prefix: bool = True) -> str:
+        """Return the reStructuredText header as a string."""
+        heading = (
+            f"Module: {self.get_title()}"
+            if include_module_prefix
+            else self.get_title()
+        )
         return f"""
 
 {heading.title()}
@@ -213,6 +217,7 @@ class ModuleDocumentation:
         self,
         subsections: str = "all",
         header: bool = True,
+        include_module_prefix: bool = True,
     ) -> str:
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Return reference documentation of all module entities.
@@ -229,6 +234,8 @@ class ModuleDocumentation:
                 If "all", all subsections will be documented.
             header: Whether to also include the header in the returned
                 documentation.
+            include_module_prefix: Whether to prefix header title with
+                ``"Module:"``.
 
         Returns:
             String with reference documentation.
@@ -250,7 +257,9 @@ class ModuleDocumentation:
         }
         lines = []
         if header:
-            lines.append(self.get_header())
+            lines.append(
+                self.get_header(include_module_prefix=include_module_prefix)
+            )
 
         annotations_ranked = _get_annotation_rank(self.ontology)
 
@@ -705,12 +714,18 @@ class ReferenceDocumentation:
             String with reference documentation.
         """
         moduledocs = []
+        nonempty_modules = [
+            md for md in self.module_documentations if md.nonempty()
+        ]
+        include_module_prefix = len(nonempty_modules) > 1
         if header:
             moduledocs.append(self.get_header())
         moduledocs.extend(
-            md.get_refdoc(subsections=subsections)
-            for md in self.module_documentations
-            if md.nonempty()
+            md.get_refdoc(
+                subsections=subsections,
+                include_module_prefix=include_module_prefix,
+            )
+            for md in nonempty_modules
         )
         return "\n".join(moduledocs)
 

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -626,8 +626,8 @@ class ModuleDocumentation:
         return lines
 
 
-class OntologyDocumentation:
-    """Documentation for an ontology with a common namespace.
+class ReferenceDocumentation:
+    """Reference documentation for ontologies.
 
     Arguments:
         ontologies: Ontologies to include in the generated documentation.
@@ -637,14 +637,18 @@ class OntologyDocumentation:
             Implies `recursive=True`.
         iri_regex: A regular expression that the IRI of documented entities
             should match.
+        title: Title of the reference index section. Defaults to
+            ``"Reference Index"``.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         ontologies: "Iterable[Ontology]",
+        *,
         imported: bool = True,
         recursive: bool = False,
         iri_regex: "Optional[str]" = None,
+        title: str = "Reference Index",
     ) -> None:
         if isinstance(ontologies, (Ontology, str, Path)):
             ontologies = [ontologies]
@@ -652,6 +656,7 @@ class OntologyDocumentation:
         if recursive:
             imported = True
 
+        self.title = title
         self.iri_regex = iri_regex
         self.module_documentations = []
 
@@ -682,12 +687,9 @@ class OntologyDocumentation:
             )
 
     def get_header(self) -> str:
-        """Return a the reStructuredText header as a string."""
-        return """
-==========
-References
-==========
-"""
+        """Return the reStructuredText header as a string."""
+        header = "=" * len(self.title)
+        return f"\n{header}\n{self.title}\n{header}\n"
 
     def get_refdoc(self, header: bool = True, subsections: str = "all") -> str:
         """Return reference documentation of all module entities.
@@ -716,7 +718,7 @@ References
         """Return the top-level ontology."""
         return self.module_documentations[0].ontology
 
-    def write_refdoc(self, docfile=None, subsections="all"):
+    def write_refdoc(self, docfile=None, subsections="all", orphan=False):
         """Write reference documentation to disk.
 
         Arguments:
@@ -725,12 +727,232 @@ References
             subsections: Comma-separated list of subsections to include in
                 the returned documentation. See ModuleDocumentation.get_refdoc()
                 for more info.
+            orphan: Whether to mark the generated page as orphaned in Sphinx.
         """
         if not docfile:
             docfile = self.top_ontology().name + ".rst"
-        Path(docfile).write_text(
-            self.get_refdoc(subsections=subsections), encoding="utf8"
+        content = self.get_refdoc(subsections=subsections)
+        if orphan:
+            content = f":orphan:\n\n{content}"
+        Path(docfile).write_text(content, encoding="utf8")
+
+
+class OntologyDocumentation:
+    """Full ontology documentation helper.
+
+    This class orchestrates full documentation generation.
+
+    Arguments:
+        ontologies: Ontologies for the primary reference index.
+        imported: Whether to include imported ontologies.
+        recursive: Whether to recursively import all imported ontologies.
+            Implies ``imported=True``.
+        iri_regex: Optional regular expression for filtering entity IRIs.
+        title: Title for the primary reference index. Default: Reference Index
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        ontologies: "Iterable[Ontology]",
+        *,
+        imported: bool = True,
+        recursive: bool = False,
+        iri_regex: "Optional[str]" = None,
+        title: str = "Reference Index",
+    ) -> None:
+        self.reference_documentations = []
+        self._reference_docnames = []
+        self._reference_subsections = []
+        self.add_reference(
+            ontologies=ontologies,
+            imported=imported,
+            recursive=recursive,
+            iri_regex=iri_regex,
+            title=title,
         )
+
+    def add_reference_documentation(
+        self,
+        reference_documentation: ReferenceDocumentation,
+        docfile: "Optional[str]" = None,
+        subsections: str = "all",
+    ) -> None:
+        """Add an existing reference documentation object.
+
+        Arguments:
+            reference_documentation: Reference section to include.
+            docfile: Optional output filename for this reference section.
+                If omitted, the top ontology name is used.
+            subsections: Comma-separated subsections to include for this
+                reference section. Defaults to ``"all"``.
+        """
+        self.reference_documentations.append(reference_documentation)
+        if docfile:
+            docname = Path(docfile).stem
+        else:
+            docname = reference_documentation.top_ontology().name
+        self._reference_docnames.append(docname)
+        self._reference_subsections.append(subsections or "all")
+
+    def add_reference(  # pylint: disable=too-many-arguments
+        self,
+        ontologies: "Iterable[Ontology]",
+        *,
+        imported: bool = True,
+        recursive: bool = False,
+        iri_regex: "Optional[str]" = None,
+        title: str = "Reference Index",
+        docfile: "Optional[str]" = None,
+        subsections: str = "all",
+    ) -> ReferenceDocumentation:
+        """Create and add a reference documentation section.
+
+        Arguments:
+            ontologies: Ontologies for the new reference section.
+            imported: Whether to include imported ontologies.
+            recursive: Whether to recursively import imported ontologies.
+            iri_regex: Optional regular expression for filtering entity IRIs.
+            title: Title for this reference section.
+            docfile: Optional output filename for this reference section.
+            subsections: Comma-separated subsections to include for this
+                reference section. Defaults to ``"all"``.
+
+        Returns:
+            The newly created :class:`ReferenceDocumentation` instance.
+        """
+        refdoc = ReferenceDocumentation(
+            ontologies=ontologies,
+            imported=imported,
+            recursive=recursive,
+            iri_regex=iri_regex,
+            title=title,
+        )
+        self.add_reference_documentation(
+            refdoc,
+            docfile=docfile,
+            subsections=subsections,
+        )
+        return refdoc
+
+    def _reference_docname(self, reference_index: int) -> str:
+        """Return output docname (without suffix) for a reference section."""
+        return self._reference_docnames[reference_index]
+
+    def top_ontology(self) -> Ontology:
+        """Return the top-level ontology of the primary reference section."""
+        return self.reference_documentations[0].top_ontology()
+
+    def get_header(self, reference_index: int = 0) -> str:
+        """Return the RST header for one reference section."""
+        return self.reference_documentations[reference_index].get_header()
+
+    def get_refdoc(
+        self,
+        header: bool = True,
+        subsections: "Optional[str]" = None,
+        reference_index: int = 0,
+    ) -> str:
+        """Return one reference section as RST.
+
+        This method keeps backward compatibility with earlier APIs by
+        defaulting to the primary reference section.
+        """
+        if subsections is None:
+            subsections = self._reference_subsections[reference_index]
+        return self.reference_documentations[reference_index].get_refdoc(
+            header=header,
+            subsections=subsections,
+        )
+
+    def get_combined_refdoc(self, subsections: "Optional[str]" = None) -> str:
+        """Return all reference sections combined in one RST string."""
+        if subsections is not None:
+            return "\n".join(
+                refdoc.get_refdoc(header=True, subsections=subsections)
+                for refdoc in self.reference_documentations
+            )
+        return "\n".join(
+            refdoc.get_refdoc(
+                header=True, subsections=self._reference_subsections[idx]
+            )
+            for idx, refdoc in enumerate(self.reference_documentations)
+        )
+
+    def write_refdoc(
+        self,
+        docfile: "Optional[str]" = None,
+        subsections: "Optional[str]" = None,
+        reference_index: int = 0,
+        orphan: bool = False,
+    ) -> None:
+        """Write one reference section to disk.
+
+        Defaults to writing the primary reference section.
+        """
+        if not docfile:
+            docfile = self._reference_docname(reference_index) + ".rst"
+        self.reference_documentations[reference_index].write_refdoc(
+            docfile=docfile,
+            subsections=(
+                subsections
+                if subsections is not None
+                else self._reference_subsections[reference_index]
+            ),
+            orphan=orphan,
+        )
+
+    def write_reference_docs(
+        self,
+        outdir: "str | Path" = ".",
+        subsections: "Optional[str]" = None,
+        overwrite: bool = False,
+    ) -> None:
+        """Write all configured reference sections to separate RST files.
+
+        Arguments:
+            outdir: Output directory for generated reference files.
+            subsections: Subsections to include in each reference section.
+            overwrite: Whether to overwrite existing files.
+        """
+        outdir = Path(outdir)
+        outdir.mkdir(parents=True, exist_ok=True)
+        for idx, _ in enumerate(self.reference_documentations):
+            outfile = outdir / f"{self._reference_docname(idx)}.rst"
+            if outfile.exists() and not overwrite:
+                warnings.warn(f"Reference file already exists: {outfile}")
+                continue
+            self.write_refdoc(
+                docfile=outfile,
+                subsections=subsections,
+                reference_index=idx,
+                orphan=(idx > 0),
+            )
+
+    def write_reference_indices_template(
+        self,
+        templatefile="_templates/reference-indices.html",
+        overwrite=False,
+    ):
+        """Write a custom sidebar template linking all reference indices."""
+        links = "\n".join(
+            [
+                "      <li><a href=\"{{ pathto('"
+                + self._reference_docname(index)
+                + "') }}\">"
+                + refdoc.title
+                + "</a></li>"
+                for index, refdoc in enumerate(self.reference_documentations)
+            ]
+        )
+        content = f"""<div class=\"sidebar-secondary-item\">\n  <div class=\"sidebar-secondary-item__title\">Reference Indices</div>\n  <ul class=\"nav bd-sidenav\">\n{links}\n  </ul>\n</div>\n"""
+        outpath = Path(templatefile)
+        if not overwrite and outpath.exists():
+            warnings.warn(
+                f"reference-indices.html file already exists: {outpath}"
+            )
+            return
+        outpath.parent.mkdir(parents=True, exist_ok=True)
+        outpath.write_text(content, encoding="utf8")
 
     def write_index_template(
         self, indexfile="index.rst", docfile=None, overwrite=False
@@ -743,13 +965,20 @@ References
                 the name of the top ontology will be used.
             overwrite: Whether to overwrite an existing file.
         """
-        docname = Path(docfile).stem if docfile else self.top_ontology().name
+        primary_docname = (
+            Path(docfile).stem if docfile else self._reference_docname(0)
+        )
+        entries = (
+            f"   {self.reference_documentations[0].title} "
+            f"<{primary_docname}.rst>"
+        )
+
         content = f"""
 .. toctree::
    :includehidden:
    :hidden:
 
-   Reference Index <{docname}.rst>
+{entries}
 
 .. include:: ../README.md
    :parser: myst_parser.sphinx_
@@ -780,7 +1009,7 @@ References
                 "OWNER/REPO".
         """
         # pylint: disable=redefined-builtin
-        md = self.module_documentations[0]
+        md = self.reference_documentations[0].module_documentations[0]
 
         iri = md.ontology.base_iri.rstrip("#/")
         authors = sorted(md.graph.objects(URIRef(iri), DCTERMS.creator))
@@ -860,7 +1089,7 @@ html_theme_options = {{
 
     # Disable right "On this page" TOC everywhere
     "show_toc_level": 0,
-    "secondary_sidebar_items": [],
+    "secondary_sidebar_items": ["reference-indices.html", "page-toc.html"],
 
     # Navbar
     "navbar_center": ["navbar-nav"],
@@ -895,7 +1124,7 @@ html_js_files = ["toc-collapsible.js"]
 
 # html_sidebars keys are docname globs. Apply everywhere unless you truly want per-page overrides.
 html_sidebars = {{
-    "{md.ontology.name.lower()}": ["search-field.html", "page-toc.html", "edit-this-page.html"],
+    "**": ["reference-indices.html", "page-toc.html", "edit-this-page.html"],
 }}
 """
 
@@ -906,6 +1135,11 @@ html_sidebars = {{
             return
 
         conffile.write_text(content, encoding="utf8")
+        self.write_reference_indices_template(
+            templatefile=Path(conffile).with_name("_templates")
+            / "reference-indices.html",
+            overwrite=True,
+        )
 
     def copy_css_file(
         self,

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -764,6 +764,7 @@ class OntologyDocumentation:
             Implies ``imported=True``.
         iri_regex: Optional regular expression for filtering entity IRIs.
         title: Title for the primary reference index. Default: Reference Index
+
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -774,6 +775,7 @@ class OntologyDocumentation:
         recursive: bool = False,
         iri_regex: "Optional[str]" = None,
         title: str = "Reference Index",
+        subsections: str = "all",
     ) -> None:
         self.reference_documentations = []
         self._reference_docnames = []
@@ -784,6 +786,7 @@ class OntologyDocumentation:
             recursive=recursive,
             iri_regex=iri_regex,
             title=title,
+            subsections=subsections,
         )
 
     def add_reference_documentation(
@@ -932,6 +935,7 @@ class OntologyDocumentation:
         outdir = Path(outdir)
         outdir.mkdir(parents=True, exist_ok=True)
         for idx, _ in enumerate(self.reference_documentations):
+
             outfile = outdir / f"{self._reference_docname(idx)}.rst"
             if outfile.exists() and not overwrite:
                 warnings.warn(f"Reference file already exists: {outfile}")
@@ -959,7 +963,7 @@ class OntologyDocumentation:
                 for index, refdoc in enumerate(self.reference_documentations)
             ]
         )
-        content = f"""<div class=\"sidebar-secondary-item\">\n  <div class=\"sidebar-secondary-item__title\">Reference Indices</div>\n  <ul class=\"nav bd-sidenav\">\n{links}\n  </ul>\n</div>\n"""
+        content = f"""<div class=\"sidebar-secondary-item\">\n  <div class=\"sidebar-secondary-item__title\">Reference Indices</div>\n  <ul class=\"bd-sidenav\">\n{links}\n  </ul>\n</div>\n"""
         outpath = Path(templatefile)
         if not overwrite and outpath.exists():
             warnings.warn(

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -1124,7 +1124,7 @@ html_js_files = ["toc-collapsible.js"]
 
 # html_sidebars keys are docname globs. Apply everywhere unless you truly want per-page overrides.
 html_sidebars = {{
-    "**": ["search-field.html", "sidebar-nav-bs.html", "edit-this-page.html"],
+    "**": ["search-field.html", "page-toc.html", "edit-this-page.html"],
 }}
 """
 

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -1089,7 +1089,7 @@ html_theme_options = {{
 
     # Disable right "On this page" TOC everywhere
     "show_toc_level": 0,
-    "secondary_sidebar_items": ["reference-indices.html", "page-toc.html"],
+    "secondary_sidebar_items": ["reference-indices.html"],
 
     # Navbar
     "navbar_center": ["navbar-nav"],
@@ -1124,7 +1124,7 @@ html_js_files = ["toc-collapsible.js"]
 
 # html_sidebars keys are docname globs. Apply everywhere unless you truly want per-page overrides.
 html_sidebars = {{
-    "**": ["reference-indices.html", "page-toc.html", "edit-this-page.html"],
+    "**": ["search-field.html", "sidebar-nav-bs.html", "edit-this-page.html"],
 }}
 """
 

--- a/ontopy/ontokit/README.md
+++ b/ontopy/ontokit/README.md
@@ -71,3 +71,31 @@ Notes on running `ontokit docs`:
   manually if you want to use `ontokit docs` without running `ontokit setup`.
   However, `ontokit setup` creates github workflow files as well,
   which might lead to changes in your already existing workflows.
+
+*  For the main reference index you can control which subsections are included. The default is
+  `all`.
+
+  ```yaml
+  REFERENCE_SUBSECTIONS: all
+  # Or, for a subset:
+  # REFERENCE_SUBSECTIONS: classes,annotation_properties,data_properties,object_properties,individuals
+  ```
+
+* It is also possible to add multiple additional reference indices in
+  `.ontokit_conf.yml` with `REFERENCE_INDICES`:
+
+  ```yaml
+  REFERENCE_INDICES:
+    - ontology_file: build/other-ontology.ttl
+      title: Other Ontology Reference
+      docfile: other-reference.rst
+      iri_regex: https://example.org/other
+      imported: false
+      recursive: false
+      subsections: all
+  ```
+
+  The `ontology_file` key is required for each entry. The generated
+  `index.rst` will include all configured reference indices. Note
+  that the creation of the ontology in the particular place (as here
+  in build) is not done by this tool.

--- a/ontopy/ontokit/config.py
+++ b/ontopy/ontokit/config.py
@@ -13,6 +13,24 @@ REQUIRED_CONFIG_KEYS = (
     "BUILD_DIR",
 )
 
+REFERENCE_INDICES_COMMENT = """\
+# Optional: select subsections for the primary reference index.
+# Default is "all".
+# REFERENCE_SUBSECTIONS: all
+# Example subset:
+# REFERENCE_SUBSECTIONS: classes,annotation_properties,data_properties,object_properties,individuals
+#
+# Optional: additional reference indices for `ontokit docs`.
+# REFERENCE_INDICES:
+#   - ontology_file: build/other-ontology.ttl
+#     title: Other Ontology Reference
+#     docfile: other-reference.rst
+#     iri_regex: https://example.org/other
+#     imported: false
+#     recursive: false
+#     subsections: all
+"""
+
 
 def get_config_path(root):
     """Return the path to the ontokit configuration file for `root`."""
@@ -22,6 +40,17 @@ def get_config_path(root):
 def _as_string(value):
     """Normalise values to strings for serialisation and substitution."""
     return "" if value is None else str(value)
+
+
+def _write_config_with_reference_indices_comment(path, config):
+    """Write config YAML and append a commented REFERENCE_INDICES example."""
+    content = yaml.safe_dump(config, sort_keys=False).rstrip()
+    # Only append when REFERENCE_INDICES is not explicitly configured.
+    if "REFERENCE_INDICES" not in config:
+        content = f"{content}\n\n{REFERENCE_INDICES_COMMENT.rstrip()}\n"
+    else:
+        content = f"{content}\n"
+    Path(path).write_text(content)
 
 
 def load_config(path):
@@ -43,7 +72,7 @@ def create_config(path, defaults):
     config = {
         key: _as_string(defaults.get(key, "")) for key in REQUIRED_CONFIG_KEYS
     }
-    Path(path).write_text(yaml.safe_dump(config, sort_keys=False))
+    _write_config_with_reference_indices_comment(path, config)
     return config
 
 
@@ -61,7 +90,7 @@ def update_config(path, config, defaults):
             config[key] = _as_string(defaults.get(key, ""))
             added.append(key)
     if added:
-        Path(path).write_text(yaml.safe_dump(config, sort_keys=False))
+        _write_config_with_reference_indices_comment(path, config)
     return config, added
 
 

--- a/ontopy/ontokit/docs.py
+++ b/ontopy/ontokit/docs.py
@@ -97,7 +97,8 @@ def docs_arguments(subparsers):
     )
 
 
-def docs_subcommand(args):  # pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,too-many-statements,too-many-branches
+def docs_subcommand(args):
     """Implements the docs sub-command."""
     root = Path(args.root).resolve()
     config_path = get_config_path(root)
@@ -120,6 +121,8 @@ def docs_subcommand(args):  # pylint: disable=too-many-locals
     ontology_name = config.get("ONTOLOGY_NAME")
     github_repository = config.get("GITHUB_REPOSITORY")
     build_dir = config.get("BUILD_DIR", "build")
+    reference_indices = config.get("REFERENCE_INDICES", [])
+    primary_subsections = config.get("REFERENCE_SUBSECTIONS", "all")
 
     # Path to ontology file
     if args.ontology_file:
@@ -135,13 +138,44 @@ def docs_subcommand(args):  # pylint: disable=too-many-locals
         iri_regex=args.iri_regex,
     )
 
+    # Optional additional reference indices provided by .ontokit_conf.yml
+    if reference_indices and not isinstance(reference_indices, list):
+        raise ValueError(
+            "REFERENCE_INDICES in .ontokit_conf.yml must be a list."
+        )
+
+    for ref in reference_indices:
+        if not isinstance(ref, dict):
+            raise ValueError("Each REFERENCE_INDICES entry must be a mapping.")
+        ref_ontology_file = ref.get("ontology_file")
+        if not ref_ontology_file:
+            raise ValueError(
+                "Each REFERENCE_INDICES entry must define 'ontology_file'."
+            )
+        ref_onto = get_ontology(root / ref_ontology_file).load()
+        od.add_reference(
+            ref_onto,
+            imported=ref.get("imported", args.imported),
+            recursive=ref.get("recursive", False),
+            iri_regex=ref.get("iri_regex", args.iri_regex),
+            title=ref.get("title", "Reference Index"),
+            docfile=ref.get("docfile"),
+            subsections=ref.get("subsections", "all"),
+        )
+
     if not args.outfile:
         docfile = root / build_dir / f"{ontology_name}.rst"
     else:
         docfile = root / Path(args.outfile)
     indexfile = docfile.with_name("index.rst")
     conffile = docfile.with_name("conf.py")
-    od.write_refdoc(docfile=docfile)
+    # Write all configured reference indices.
+    od.write_reference_docs(outdir=docfile.parent, overwrite=True)
+    od.write_refdoc(
+        docfile=docfile,
+        reference_index=0,
+        subsections=primary_subsections,
+    )
     # if not indexfile.exists():
     od.write_index_template(
         indexfile=indexfile, docfile=docfile, overwrite=True
@@ -153,7 +187,7 @@ def docs_subcommand(args):  # pylint: disable=too-many-locals
         overwrite=True,
         github_repository=github_repository,
     )
-    (Path(build_dir) / "_static").mkdir(parents=True, exist_ok=True)
+    (root / build_dir / "_static").mkdir(parents=True, exist_ok=True)
 
     od.copy_css_file()  # Use default CSS file
     od.copy_js_file()  # Use default collapsible-TOC JS file

--- a/ontopy/ontokit/docs.py
+++ b/ontopy/ontokit/docs.py
@@ -122,7 +122,7 @@ def docs_subcommand(args):
     github_repository = config.get("GITHUB_REPOSITORY")
     build_dir = config.get("BUILD_DIR", "build")
     reference_indices = config.get("REFERENCE_INDICES", [])
-    primary_subsections = config.get("REFERENCE_SUBSECTIONS", "all")
+    # primary_subsections = config.get("REFERENCE_SUBSECTIONS", "all")
 
     # Path to ontology file
     if args.ontology_file:
@@ -171,11 +171,11 @@ def docs_subcommand(args):
     conffile = docfile.with_name("conf.py")
     # Write all configured reference indices.
     od.write_reference_docs(outdir=docfile.parent, overwrite=True)
-    od.write_refdoc(
-        docfile=docfile,
-        reference_index=0,
-        subsections=primary_subsections,
-    )
+    # od.write_refdoc(
+    #    docfile=docfile,
+    ##    reference_index=0,
+    #    subsections=primary_subsections,
+    # )
     # if not indexfile.exists():
     od.write_index_template(
         indexfile=indexfile, docfile=docfile, overwrite=True

--- a/ontopy/ontokit/docs.py
+++ b/ontopy/ontokit/docs.py
@@ -122,7 +122,7 @@ def docs_subcommand(args):
     github_repository = config.get("GITHUB_REPOSITORY")
     build_dir = config.get("BUILD_DIR", "build")
     reference_indices = config.get("REFERENCE_INDICES", [])
-    # primary_subsections = config.get("REFERENCE_SUBSECTIONS", "all")
+    primary_subsections = config.get("REFERENCE_SUBSECTIONS", "all")
 
     # Path to ontology file
     if args.ontology_file:
@@ -136,6 +136,7 @@ def docs_subcommand(args):
         onto,
         recursive=args.imported,
         iri_regex=args.iri_regex,
+        subsections=primary_subsections,
     )
 
     # Optional additional reference indices provided by .ontokit_conf.yml
@@ -171,22 +172,17 @@ def docs_subcommand(args):
     conffile = docfile.with_name("conf.py")
     # Write all configured reference indices.
     od.write_reference_docs(outdir=docfile.parent, overwrite=True)
-    # od.write_refdoc(
-    #    docfile=docfile,
-    ##    reference_index=0,
-    #    subsections=primary_subsections,
-    # )
-    # if not indexfile.exists():
-    od.write_index_template(
-        indexfile=indexfile, docfile=docfile, overwrite=True
-    )
-    # if not conffile.exists():
-    od.write_conf_template(
-        conffile=conffile,
-        docfile=docfile,
-        overwrite=True,
-        github_repository=github_repository,
-    )
+    if not indexfile.exists():
+        od.write_index_template(
+            indexfile=indexfile, docfile=docfile, overwrite=True
+        )
+    if not conffile.exists():
+        od.write_conf_template(
+            conffile=conffile,
+            docfile=docfile,
+            overwrite=True,
+            github_repository=github_repository,
+        )
     (root / build_dir / "_static").mkdir(parents=True, exist_ok=True)
 
     od.copy_css_file()  # Use default CSS file

--- a/ontopy/ontokit/setuptemplates/js/toc-collapsible.js
+++ b/ontopy/ontokit/setuptemplates/js/toc-collapsible.js
@@ -1,8 +1,8 @@
 /**
  * toc-collapsible.js
  *
- * Adds collapse/expand toggle buttons to every level of the page-TOC
- * sidebar rendered by pydata-sphinx-theme's page-toc.html.
+ * Adds collapse/expand toggle buttons to every level of the left
+ * navigation sidebar rendered by pydata-sphinx-theme.
  *
  * Each <li> that contains a nested <ul> gets a small chevron button
  * inserted as the first child (left gutter), similar to tree controls
@@ -10,14 +10,10 @@
  * child list.
  */
 document.addEventListener("DOMContentLoaded", function () {
-  // pydata-sphinx-theme wraps the page-toc in a <nav> inside the
-  // primary sidebar.  We cast a wide net across possible class names
-  // used by different versions of the theme.
+  // Target navigation in the primary (left) sidebar.
   const tocNavs = document.querySelectorAll(
     ".bd-sidebar-primary nav, " +
-    ".sidebar-primary-item nav, " +
-    ".bd-toc-nav, " +
-    "[aria-label='Page'] ul"
+    ".sidebar-primary-item nav"
   );
 
   if (!tocNavs.length) return;
@@ -32,13 +28,17 @@ document.addEventListener("DOMContentLoaded", function () {
       const btn = document.createElement("button");
       btn.className = "toc-toggle-btn";
       btn.setAttribute("aria-label", "Toggle subsection");
-      btn.setAttribute("aria-expanded", "true");
-      btn.textContent = "\u25BE"; // ▾ (expanded)
+      btn.setAttribute("aria-expanded", "false");
+      btn.textContent = "\u25B8"; // ▸ (collapsed)
       btn.title = "Collapse/expand";
 
       // Mark items with children and place chevron in left gutter.
       li.classList.add("toc-has-children");
       li.prepend(btn);
+
+      // Start collapsed by default.
+      childUl.classList.add("toc-items-collapsed");
+      li.classList.add("toc-collapsed");
 
       btn.addEventListener("click", function (e) {
         e.preventDefault();

--- a/tests/test_ontodoc_rst.py
+++ b/tests/test_ontodoc_rst.py
@@ -4,10 +4,11 @@
 # if True:
 def test_ontodoc():
     """Test ontodoc."""
-    from pathlib import Path
-
     from ontopy import get_ontology
-    from ontopy.ontodoc_rst import OntologyDocumentation
+    from ontopy.ontodoc_rst import (
+        OntologyDocumentation,
+        ReferenceDocumentation,
+    )
     from ontopy.testutils import ontodir
     import owlready2
 
@@ -17,5 +18,29 @@ def test_ontodoc():
 
     od = OntologyDocumentation(
         onto, recursive=True, iri_regex="https://w3id.org/emmo"
+    )
+    ref = ReferenceDocumentation(
+        onto,
+        recursive=True,
+        iri_regex="https://w3id.org/emmo",
+        title="Mammal Reference",
+    )
+
+    od.add_reference(
+        onto,
+        recursive=True,
+        iri_regex="https://w3id.org/emmo",
+        title="Second Mammal Reference",
+        docfile="mammal-second.rst",
+        subsections="classes",
+    )
+
+    assert "Mammal Reference" in ref.get_refdoc()
+    combined = od.get_combined_refdoc()
+    assert "Reference Index" in combined
+    assert "Second Mammal Reference" in combined
+    assert od.get_refdoc(reference_index=1) == od.get_refdoc(
+        reference_index=1,
+        subsections="classes",
     )
     print(od.get_refdoc())


### PR DESCRIPTION
This allowed for inserting more than one reference index

# Description
<!-- Summary of change, including the issue(s) to be addressed. -->

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

