### PR TITLE
Added a javascript for navigating to a section with a query parameter.

### DIFF
--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -891,7 +891,7 @@ html_theme_options = {{
 html_static_path = ["_static"]
 html_title = f"{md.ontology.name.capitalize()} Ontology"
 html_css_files = ["custom.css"]
-html_js_files = ["toc-collapsible.js"]
+html_js_files = ["toc-collapsible.js", "section-nav.js"]
 
 # html_sidebars keys are docname globs. Apply everywhere unless you truly want per-page overrides.
 html_sidebars = {{
@@ -952,16 +952,17 @@ html_sidebars = {{
 
     def copy_js_file(
         self,
-        source: str | Path = (SETUPTEMPLATES_DIR / "js" / "toc-collapsible.js"),
+        source: str | Path = (SETUPTEMPLATES_DIR / "js"),
     ) -> Path:
         """
-        Copy the collapsible-TOC JavaScript file into the Sphinx HTML
-        static directory.
+        Copy JavaScript file(s) from `source` into the Sphinx HTML static
+        directory.
 
         The source may be:
           - a URL (http/https),
-          - an absolute local path,
-          - a relative local path.
+          - an absolute or relative local path,
+          - an absolute or relative local directory (all .js files in the
+            directory are copied).
 
         Parameters
         ----------
@@ -989,7 +990,11 @@ html_sidebars = {{
             source_path = Path(source)
             if not source_path.exists():
                 raise FileNotFoundError(f"JS source not found: {source_path}")
-            shutil.copyfile(source_path, destination)
+            if source_path.is_dir():
+                for jsfile in source_path.glob("*.js"):
+                    shutil.copyfile(jsfile, destination)
+            else:
+                shutil.copyfile(source_path, destination)
 
-        print(f"Copied JS file to: {destination}")
+        print(f"Copied JS file(s) to: {destination}")
         return destination

--- a/ontopy/ontokit/setuptemplates/js/section-nav.js
+++ b/ontopy/ontokit/setuptemplates/js/section-nav.js
@@ -31,7 +31,7 @@
 
     if (target) {
         // Scroll to the element
-        target.scrollIntoView({ behavior: "smooth" });
+        target.scrollIntoView({ behavior: "instant" });
 
         // OPTIONAL: clean up the URL and convert ?section=... into a hash
         // So the URL becomes page.html#my-heading

--- a/ontopy/ontokit/setuptemplates/js/section-nav.js
+++ b/ontopy/ontokit/setuptemplates/js/section-nav.js
@@ -1,0 +1,44 @@
+/**
+ * section-nav.js
+ *
+ * A javascript that enables navigation in generated documentation using a
+ * query parameter. E.g.
+ *
+ *     page.html?section=my-heading
+ *
+ * will navigate to section "my-heading".
+ *
+ * This script will:
+ *   - Read the section query parameter
+ *   - Locate the element whose id matches the value
+ *   - Scroll to that element
+ *   - Optionally rewrite the URL to use a clean #fragment instead of the
+ *     query parameter
+ * This works with any Sphinx theme (Read the Docs, basic, Alabaster, etc.)
+ * because it only depends on standard DOM APIs.
+ */
+(function() {
+    // Parse the query parameters
+    const params = new URLSearchParams(window.location.search);
+    const section = params.get("section");
+
+    if (!section) {
+        return; // Nothing to do
+    }
+
+    // Attempt to find the element by ID (Sphinx uses IDs for headings)
+    const target = document.getElementById(section);
+
+    if (target) {
+        // Scroll to the element
+        target.scrollIntoView({ behavior: "smooth" });
+
+        // OPTIONAL: clean up the URL and convert ?section=... into a hash
+        // So the URL becomes page.html#my-heading
+        history.replaceState(
+            null,
+            "",
+            window.location.pathname + "#" + section
+        );
+    }
+})();


### PR DESCRIPTION
# Description
It is not possible to create redirection rules to URL fragments. 
To redirect an IRI of an ontological concept to its documentation we therefore have to use a query parameter.

This PR adds a javascript that, given the URI `page.html?section=my-heading` navigates to section "my-heading" in the similar way that `page.html#my-heading` would have done.

**WARNING**: untested code...


## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
