### PR TITLE
Correct links

### DIFF
--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -474,7 +474,6 @@ class ModuleDocumentation:
                 if hasattr(entity, "get_annotations") or hasattr(
                     entity, "get_individual_annotations"
                 ):
-                    add_header("Annotations")
                     annotations = {  # pylint: disable=protected-access
                         a: a._get_values_for_class(  # pylint: disable=protected-access
                             entity
@@ -484,6 +483,8 @@ class ModuleDocumentation:
                             entity
                         )
                     }
+                    if len(annotations) > 0:
+                        add_header("Annotations")
 
                     long_annotations = [
                         "http://www.w3.org/2004/02/skos/core#example",
@@ -552,9 +553,9 @@ class ModuleDocumentation:
                             )
                         # Add SubclassOf/SubPropertyOf/InstanceOf for direct parents
                         if isinstance(entity, owlready2.ThingClass):
-                            add_keyvalue("Subclass Of", parents)
+                            add_keyvalue("subClassOf", parents)
                         elif isinstance(entity, (owlready2.PropertyClass)):
-                            add_keyvalue("Subproperty Of", parents)
+                            add_keyvalue("subPropertyOf", parents)
                         elif isinstance(entity, owlready2.Thing):
                             add_keyvalue("Instance of", parents)
                         # Add Subclasses if any

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -318,11 +318,11 @@ class ModuleDocumentation:
                 # Link to the full IRI if it's not documented on this page
                 return f"<a href='{full_iri}'>{display_text}</a>"
 
-            fragment_iri = getiriname(full_iri)
+            name = getiriname(full_iri)
             return (
-                f"<a href='#{fragment_iri}' "
+                f"<a href='#{name}' "
                 f'onclick="'
-                f"if(!document.getElementById('{fragment_iri}'))"
+                f"if(!document.getElementById('{name}'))"
                 f"{{window.location.href='{full_iri}'; return false;}}"
                 f'">'
                 f"{display_text}</a>"

--- a/ontopy/ontodoc_rst.py
+++ b/ontopy/ontodoc_rst.py
@@ -255,6 +255,13 @@ class ModuleDocumentation:
             "individuals": self.individuals,
             "datatypes": self.datatypes,
         }
+        # Get all IRIs that will be documented on this page
+        page_entity_iris = {
+            entity.iri
+            for subsection in subsections.split(",")
+            for entity in maps[subsection]
+            if hasattr(entity, "iri")
+        }
         lines = []
         if header:
             lines.append(
@@ -307,6 +314,10 @@ class ModuleDocumentation:
             """Create the HTML code so that links lead to
             the correct fragment in the same document if possibe,
             otherwise link to the full IRI"""
+            if full_iri not in page_entity_iris:
+                # Link to the full IRI if it's not documented on this page
+                return f"<a href='{full_iri}'>{display_text}</a>"
+
             fragment_iri = getiriname(full_iri)
             return (
                 f"<a href='#{fragment_iri}' "

--- a/tests/test_ontodoc_rst.py
+++ b/tests/test_ontodoc_rst.py
@@ -47,23 +47,45 @@ def test_ontodoc():
 
 
 def test_ontodoc_slash_namespace_internal_links():
-    """Internal links should resolve for slash-style namespace IRIs."""
+    """Internal links should stay distinct for same labels across ontologies."""
     import owlready2
 
     from ontopy import get_ontology
-    from ontopy.ontodoc_rst import ModuleDocumentation
+    from ontopy.ontodoc_rst import ReferenceDocumentation
 
     onto = get_ontology("http://example.com/onto/")
+    onto2 = get_ontology("http://example.com/anotheronto/")
+    onto.imported_ontologies.append(onto2)
+
+    with onto2:
+
+        class Animal(owlready2.Thing):
+            pass
+
     with onto:
 
         class Animal(owlready2.Thing):
             pass
 
-        class Dog(Animal):
+        class Dog(Animal, onto2.Animal):
             pass
 
-    doc = ModuleDocumentation(onto).get_refdoc(subsections="classes")
+    doc = ReferenceDocumentation(onto, imported=False).get_refdoc(
+        subsections="classes"
+    )
+    print(doc)
 
     assert '<div id="Animal"></div>' in doc
-    assert "href='#Animal'" in doc
     assert "href='#http://example.com/onto/Animal'" not in doc
+    assert "href='#http://example.com/anotheronto/Animal'" not in doc
+    assert (
+        "<a href='#Animal' onclick=\"if(!document.getElementById('Animal'))"
+        "{window.location.href='http://example.com/onto/Animal'; "
+        'return false;}">Animal</a>'
+    ) in doc
+    assert ("<a href='http://example.com/anotheronto/Animal'>Animal</a>") in doc
+    assert (
+        "<a href='#Animal' onclick=\"if(!document.getElementById('Animal'))"
+        "{window.location.href='http://example.com/anotheronto/Animal'; "
+        'return false;}">Animal</a>'
+    ) not in doc


### PR DESCRIPTION
# Description
Current implementation is that the link is always created to the current page if the label is documented in the same page. 
This is wrong in cases where we have labeled something in the same way as something we refer to outside of the current ontology.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Test update.

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

This checklist can be used as a help for the reviewer.

- [ ] Is the code easy to read and understand?
- [ ] Are comments for humans to read, not computers to disregard?
- [ ] Does a new feature has an accompanying new test (in the CI or unit testing schemes)?
- [ ] Has the documentation been updated as necessary?
- [ ] Does this close the issue?
- [ ] Is the change limited to the issue?
- [ ] Are errors handled for all outcomes?
- [ ] Does the new feature provide new restrictions on dependencies, and if so is this documented?

## Comments
<!-- Additional comments here, including clarifications on checklist if applicable. -->
